### PR TITLE
Ensure omnibus-package tests are testing omnibus

### DIFF
--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -235,6 +235,9 @@ describe ChefCLI::CLI do
     end
 
     context "when installed via omnibus" do
+      before do
+        allow(cli).to receive(:omnibus_install?).and_return true
+      end
 
       context "on unix" do
 
@@ -345,6 +348,9 @@ describe ChefCLI::CLI do
 
     context "when not installed via omnibus" do
 
+      before do
+        allow(cli).to receive(:omnibus_install?).and_return false
+      end
       let(:ruby_path) { "/Users/bog/.lots_o_rubies/2.1.2/bin/ruby" }
       let(:expected_root_path) { "/Users/bog/.lots_o_rubies" }
 

--- a/spec/unit/command/generator_commands/base_spec.rb
+++ b/spec/unit/command/generator_commands/base_spec.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-require "pry"
 require "spec_helper"
 require "chef-cli/command/generator_commands/base"
 


### PR DESCRIPTION
## Description

The tests for CLI sanity check were failing because we hadn't told the CLI to pretend it was an omnibus install; and the testers aren't running out of omnibus package. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] n/a ~I have updated the documentation accordingly.~
- [ ] n/a ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
