### PR TITLE
Wire the provision command back up so the deprecation warning works

### DIFF
--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -59,4 +59,7 @@ ChefCLI.commands do |c|
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
 
   c.builtin "verify", :Verify, desc: "Test the embedded #{ChefCLI::Dist::PRODUCT} applications", hidden: true
+
+  # deprecated command that throws a failure warning if used. This was removed 4.2019
+  c.builtin "provision", :Provision, desc: "Provision VMs and clusters via cookbook", hidden: true
 end


### PR DESCRIPTION
I nuked this in DK 4 / Workstation 0.4 without understanding exactly what this file did. We want the command to run so it can throw the deprecation warning.

Signed-off-by: Tim Smith <tsmith@chef.io>