### PR TITLE
Disable chef-run telemetry data during CI tests

### DIFF
--- a/lib/chef-cli/command/verify.rb
+++ b/lib/chef-cli/command/verify.rb
@@ -197,7 +197,7 @@ module ChefCLI
       #     bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
       #     sh("#{embedded_bin("bundle")} exec rspec")
       #   end
-        c.smoke_test { sh("#{bin("chef-run")} -v") }
+        c.smoke_test { sh("#{bin("chef-run")} -v", env: { "CHEF_TELEMETRY_OPT_OUT" => "true" }) }
       end
 
       add_component "chefspec" do |c|


### PR DESCRIPTION
## Description
This environment variable will currently disable _writing_ telemetry data, which solves the problem of junk data getting into our telemetry database. But https://github.com/chef/chef-apply/pull/96 will help optimize `chef-run` by also not attempting to send anything.

## Related Issue
https://github.com/chef/chef-apply/pull/96

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
