### PR TITLE
Prototype chef test command to provide backwards compat for delivery local mode

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency "tomlrb", "~> 1.2" # legacy delivery local mode config parsing
   gem.add_dependency "mixlib-cli", ">= 1.7", "< 3.0"
   gem.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"

--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -58,6 +58,8 @@ ChefCLI.commands do |c|
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-cli/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
 
+  c.builtin "test", :Test, desc: "Test your #{ChefCLI::Dist::INFRA_PRODUCT} cookbook code"
+
   c.builtin "verify", :Verify, desc: "Test the embedded #{ChefCLI::Dist::PRODUCT} applications", hidden: true
 
   # deprecated command that throws a failure warning if used. This was removed 4.2019

--- a/lib/chef-cli/command/test.rb
+++ b/lib/chef-cli/command/test.rb
@@ -1,0 +1,107 @@
+#
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "base"
+require_relative "../ui"
+require_relative "../test_config"
+require_relative "../dist"
+
+module ChefCLI
+  module Command
+
+    class Test < Base
+
+      banner(<<~E)
+        Usage: #{ChefCLI::Dist::EXEC} test [PHASE] [options]
+
+        `#{ChefCLI::Dist::EXEC} test` tests your cookbook code using existing Delivery Local-Mode configuration files at .delivery/project.toml
+
+        Options:
+
+      E
+
+      option :config_file,
+        short:       "-c CONFIG_FILE",
+        long:        "--config CONFIG_FILE",
+        description: "Path to configuration file",
+        default:     File.expand_path(".delivery/project.toml")
+
+      option :debug,
+        short:       "-D",
+        long:        "--debug",
+        description: "Enable stacktraces and other debug output",
+        default:     false
+
+      attr_accessor :ui
+
+      def initialize(*args)
+        super
+        @ui = UI.new
+        @test_config = TestConfig.new(config_path)
+      end
+
+      def run(params)
+        @test_config.validate!
+
+        # start by building out a hash of what phases to run so we can fail
+        # if any of the phases were invalid before we start
+        commands_to_run(params).each do |phase, command|
+          puts "Running phase #{phase} command #{command}"
+        end
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def config_path
+        config[:config_file]
+      end
+
+      private
+
+      def commands_to_run(phases)
+        # if no phase or all specified then return all phases
+        return @test_config.config_hash["local_phases"] if phases.empty? || phases.include?("all")
+
+        to_run = {}
+
+        phases.each do |phase|
+          to_run[phase] = lookup_phase_cmd(phase)
+        end
+
+        to_run
+      end
+
+      def lookup_phase_cmd(phase)
+        raise "Phase #{phase} not found in #{config_path}!" unless @test_config.config_hash["local_phases"].key?(phase)
+
+        @test_config.config_hash["local_phases"][phase]
+      end
+
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+    end
+  end
+end

--- a/lib/chef-cli/test_config.rb
+++ b/lib/chef-cli/test_config.rb
@@ -1,0 +1,75 @@
+#
+# Copyright:: Copyright (c) 2019 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "tomlrb"
+require "net/http"
+
+module ChefCLI
+  class TestConfig
+
+    def initialize(path = nil)
+      @config_path = path
+      @config_hash = load_config_file(@config_path)
+      @version = @config_hash.nil? ? nil : 0 # 0 means the delivery project.toml
+    end
+
+    attr_accessor :config_hash
+    attr_accessor :version
+
+    def validate!
+      raise "No config content found in #{@config_path}!" if @config_hash.nil?
+      raise "No phases defined in the #{@config_path}. Make sure it contains a [local_phases] section." unless @config_hash["local_phases"]
+    end
+
+    private
+
+    def load_config_file(config_path)
+      raise "No test config found at #{@config_path}" unless File.exist?(@config_path)
+
+      config = load_toml_file(config_path)
+
+       # if there's a remote_file config option then return that content. Otherwise use what we have
+      if config.key?("remote_file")
+        parse_toml(fetch_remote_content(config["remote_file"]))
+      else
+        return config
+      end
+    end
+
+    def load_toml_file(path)
+      Tomlrb.load_file(path)
+    rescue => e
+      message = "Unable to parse the Delivery Local Mode config file: #{path}\n"
+      message << e.message
+      raise message
+    end
+
+    def parse_toml(content)
+      Tomlrb.parse(content)
+    rescue => e
+      message = "Unable to parse the Delivery Local Mode config's remote_file content\n"
+      message << e.message
+      raise message
+    end
+
+    def fetch_remote_content(uri)
+      Net::HTTP.get(URI(uri))
+    rescue Errno::ECONNREFUSED
+      raise "Could not connect to the host to fetch the remote configuration file at #{uri}"
+    end
+  end
+end


### PR DESCRIPTION
### Long term goal:

Provide a one stop shop test command that just does the right thing out of the box. Abstract away the underlying tools so that a user doesn't need to know individual commands and can run just a single command to test their infrastructure. This might sound a bit familiar since this was the goal of Delivery Local Mode.

### How did Delivery Local Mode Work?

Delivery Local Mode provided a simple config in .delivery/project.toml that defined commands to run for each of a predefined set of phases. It also allowed you define a URL where a config was located so all your cookbooks could use a single remote config that was easy to update. You ran your tests with delivery local PHASE or delivery local all to run all phases.

### Short term goal of this PR:

Stop shipping the delivery command in Chef Workstation, while providing compatibility for users utilizing the Delivery Local Mode workflow. This PR lacks the actual shellout functionality, debug logging, or any error handling, but it shows the concept of how this would work from the user's perspective. A user could run one of the following commands:
- chef test all: run all phases in the project.toml file
- chef test PHASE: run a single phase in the project.toml file
- chef test: run all phases (all is implied) in the project.toml file

If a remote config is defined in the local project.toml file that will be fetched and parsed as well.

### Next step:

- Add the actual shellout
- Add error handling
- Add debug logging
- Add tests
- Add a shim delivery command to chef-cli. This command will act as a pass-through if a delivery command is found in the path, but otherwise it'll provide full compatibility for users running the legacy `delivery local` command

From here we can implement a v1 test solution (delivery local mode being v0) with its own config. This PR code would be the fallback legacy mode when a delivery config was found. The code would live on for some period of time while it warned users to upgrade to the new testing method.

### What it looks like for the user:

Running all phases in a remote config:
```
$ chef test
Running phase unit command rspec spec/
Running phase lint command cookstyle --display-cop-names --extra-details
Running phase syntax command foodcritic .
Running phase provision command echo skipping
Running phase deploy command echo skipping
Running phase smoke command echo skipping
Running phase functional command echo skipping
Running phase cleanup command echo skipping
```

Running just a single phase in a remote config
```
$ chef test unit
Running phase unit command rspec spec/
```


Signed-off-by: Tim Smith <tsmith@chef.io>