### PR TITLE
Loosen the Chef dependency to allow 14.x or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -5,6 +5,15 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
+- label: run-specs-ruby-2.4
+  command:
+    - bundle install --jobs=7 --retry=3 --without docs development
+    - export USER="root"
+    - bundle exec rspec
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.4-stretch
 - label: run-specs-ruby-2.5
   command:
     - bundle install --jobs=7 --retry=3 --without docs development

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ group :docs do
 end
 
 group :test do
+  # For ruby 2.4 testing we need to use ohai 14
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
+    gem "ohai", "~> 14"
+  end
   gem "rake"
   gem "rspec", "~> 3.8"
   gem "rspec-expectations", "~> 3.8"

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
   gem.homepage      = "https://www.chef.io/"
 
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.files = %w{Rakefile LICENSE} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
   gem.add_dependency "minitar", "~> 0.6"
-  gem.add_dependency "chef", "~> 15.0"
+  gem.add_dependency "chef", ">= 14.0"
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.6"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"


### PR DESCRIPTION
Chefspec is going to use chef-cli and chefspec supports older Chef releases. There's no reason to set the floor here to 15 when 14 will work just fine. This also allows Ruby 2.4 which is supported by Chef 14.

Signed-off-by: Tim Smith <tsmith@chef.io>