### PR TITLE
Remove knife-spork verification, and berks integration tests

### DIFF
--- a/lib/chef-cli/command/verify.rb
+++ b/lib/chef-cli/command/verify.rb
@@ -92,10 +92,14 @@ module ChefCLI
           bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
           sh("#{embedded_bin("bundle")} exec #{embedded_bin("rspec")} --color --format progress spec/unit --tag ~graphviz")
         end
-        c.integration_test do
-          bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
-          sh("#{embedded_bin("bundle")} exec #{embedded_bin("cucumber")} --color --format progress --tags ~@no_run --tags ~@spawn --tags ~@graphviz --strict")
-        end
+
+        # See older versions of this file in git to retrieve
+        # our cucumber test command for berkshelf.
+        # We had to remove them because we no longer bundle These tests cannot be run unless we bundle cucumber
+        # c.integration_test do
+        #   bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
+        #   sh("#{embedded_bin("bundle")} exec #{embedded_bin("cucumber")} --color --format progress --tags ~@no_run --tags ~@spawn --tags ~@graphviz --strict")
+        # end
 
         c.smoke_test do
           tmpdir do |cwd|
@@ -246,11 +250,6 @@ module ChefCLI
       add_component "fauxhai" do |c|
         c.gem_base_dir = "fauxhai"
         c.smoke_test { sh("#{embedded_bin("gem")} list fauxhai") }
-      end
-
-      add_component "knife-spork" do |c|
-        c.gem_base_dir = "knife-spork"
-        c.smoke_test { sh("#{bin("knife")} spork info") }
       end
 
       add_component "kitchen-vagrant" do |c|

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -46,7 +46,6 @@ describe ChefCLI::Command::Verify do
       "chefspec",
       "generated-cookbooks-pass-chefspec",
       "fauxhai",
-      "knife-spork",
       "kitchen-vagrant",
       "package installation",
       "openssl",


### PR DESCRIPTION
The knife-spork plugin is being removed from Chef Workstation.
Cucumber is also being removed, so we can't use it to run
an integration test.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
