### PR TITLE
Add missing require for 'chef-cli/cli' in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ require "test_helpers"
 require "chef/workstation_config_loader"
 require "chef/config"
 
+require "chef-cli/cli"
+
 RSpec.configure do |c|
   running_on_windows = (RUBY_PLATFORM =~ /mswin|mingw|windows/)
 


### PR DESCRIPTION
spec_helper references ChefCLI but does not include the file.
This is causing verification tests to fail in Workstation

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All  existing tests passed.

