### PR TITLE
Shellout libraries expect cwd to be provided as a string

### DIFF
--- a/lib/chef-cli/policyfile/git_lock_fetcher.rb
+++ b/lib/chef-cli/policyfile/git_lock_fetcher.rb
@@ -195,7 +195,7 @@ module ChefCLI
       #
       # @return [String] Content of specified file for a given revision.
       def show_file(version, file)
-        git("show #{version}:#{file}", cwd: cache_path)
+        git("show #{version}:#{file}", cwd: cache_path.to_s)
       end
 
       # COPYPASTA from CookbookOmnifetch

--- a/spec/unit/policyfile/git_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/git_lock_fetcher_spec.rb
@@ -120,6 +120,17 @@ describe ChefCLI::Policyfile::GitLockFetcher do
       expect(lock_data).to include(minimal_lockfile_modified)
     end
 
+    # Shellout libraries on Windows expect cwd to be provided as a string, not Pathname object
+    it "provides the working directory as a string" do
+      expect(Mixlib::ShellOut).to receive(:new).with(/git clone/, {}).and_return(shellout)
+      expect(Mixlib::ShellOut).to receive(:new).with(/git show/, { cwd: /cache/ }).and_return(shellout)
+      allow(shellout).to receive(:error?).and_return(false)
+      allow(shellout).to receive(:stdout).and_return(minimal_lockfile_json)
+      allow(Dir).to receive(:chdir).and_return(0)
+
+      expect(lock_data).to include(minimal_lockfile_modified)
+    end
+
     context "when using a relative path for the policyfile" do
       let(:source_options_rel) do
         source_options.collect { |k, v| [k.to_s, v] }.to_h.merge({ "rel" => rel })


### PR DESCRIPTION
## Description
When `cwd` is provided as a `Pathname` object the Windows shellout
library raises a stack from https://github.com/chef/mixlib-shellout/blob/v2.4.4/lib/mixlib/shellout/windows/core_ext.rb#L235
because a `Pathname` does not have `to_wide_string` defined on it.

I decided to fix the bug in chef-cli rather than trying to convert all
args passed to `Shellout.new` to strings because no other values are
converted (although keys are).

If we want to fix this in mixlib-shellout we could call `.to_s.to_wide_string` at https://github.com/chef/mixlib-shellout/blob/v2.4.4/lib/mixlib/shellout/windows/core_ext.rb#L235

## Related Issue
Fixes https://github.com/chef/chef-cli/issues/25

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
