### PR TITLE
Don't generate cookbooks with long_description metadata

### DIFF
--- a/lib/chef-cli/command/generator_commands/generator_generator.rb
+++ b/lib/chef-cli/command/generator_commands/generator_generator.rb
@@ -111,7 +111,6 @@ module ChefCLI
           <<~METADATA
             name             '#{cookbook_name}'
             description      'Custom code generator cookbook for use with #{ChefCLI::Dist::PRODUCT}'
-            long_description 'Custom code generator cookbook for use with #{ChefCLI::Dist::PRODUCT}'
             version          '0.1.0'
 
           METADATA

--- a/lib/chef-cli/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -3,7 +3,6 @@ maintainer '<%= copyright_holder %>'
 maintainer_email '<%= email %>'
 license '<%= @spdx_license %>'
 description 'Installs/Configures <%= cookbook_name %>'
-long_description 'Installs/Configures <%= cookbook_name %>'
 version '0.1.0'
 chef_version '>= 14.0'
 

--- a/spec/unit/command/generator_commands/generator_generator_spec.rb
+++ b/spec/unit/command/generator_commands/generator_generator_spec.rb
@@ -183,7 +183,6 @@ describe ChefCLI::Command::GeneratorCommands::GeneratorGenerator do
         expected_metadata = <<~METADATA
           name             'my_cool_generator'
           description      'Custom code generator cookbook for use with #{ChefCLI::Dist::PRODUCT}'
-          long_description 'Custom code generator cookbook for use with #{ChefCLI::Dist::PRODUCT}'
           version          '0.1.0'
 
         METADATA


### PR DESCRIPTION
This field is unused and we're removing it via cookstyle now. We shouldn't generate new cookbooks with it.

Signed-off-by: Tim Smith <tsmith@chef.io>