### PR TITLE
Remove foodcritic from the delivery local config in the generator

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -53,16 +53,6 @@ steps:
       docker:
         host_os: windows
 
-- label: foodcritic-generator-cb-tests-ruby-2.6
-  command:
-    - export USER="root"
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake style:foodcritic
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-stretch
-
 - label: cookstyle-generator-cb-tests-ruby-2.6
   command:
     - export USER="root"

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :test do
   gem "rspec-mocks", "~> 3.8"
   gem "cookstyle"
   gem "chefstyle"
-  gem "foodcritic"
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -51,20 +51,4 @@ namespace :style do
   rescue LoadError => e
     puts ">>> Gem load error: #{e}, omitting #{task.name}" unless ENV["CI"]
   end
-
-  begin
-    require "foodcritic"
-
-    desc "Run Chef Cookbook (Foodcritic) style checks"
-    FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
-      t.options = {
-        fail_tags: ["any"],
-        tags: ["~FC071", "~supermarket", "~FC031"],
-        cookbook_paths: ["lib/chef-cli/skeletons/code_generator"],
-        progress: true,
-      }
-    end
-  rescue LoadError => e
-    puts ">>> Gem load error: #{e}, omitting #{task.name}" unless ENV["CI"]
-  end
 end

--- a/lib/chef-cli/skeletons/code_generator/files/default/build_cookbook/README.md
+++ b/lib/chef-cli/skeletons/code_generator/files/default/build_cookbook/README.md
@@ -129,7 +129,7 @@ delivery review
 
 ## FAQ
 
-### Why don't I just run rspec and foodcritic/rubocop on my local system?
+### Why don't I just run rspec and foodcritic/cookstyle on my local system?
 
 An objection to the Test Kitchen approach is that it is much faster to run the unit, lint, and syntax commands for the project on the local system. That is totally true, and also totally valid. Do that for the really fast feedback loop. However, the dance we do with Test Kitchen brings a much higher degree of confidence in the changes we're making, that everything will run on the build nodes in Chef Workflow. We strongly encourage this approach before actually pushing the changes to Workflow.
 

--- a/lib/chef-cli/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-cli/skeletons/code_generator/files/default/delivery-project.toml
@@ -11,11 +11,9 @@
 [local_phases]
 unit = "chef exec rspec spec/"
 lint = "chef exec cookstyle"
-# Foodcritic includes rules only appropriate for community cookbooks
-# uploaded to Supermarket. We turn off any rules tagged "supermarket"
-# by default. If you plan to share this cookbook you should remove
-# '-t ~supermarket' below to enable supermarket rules.
-syntax = "chef exec foodcritic . -t ~supermarket"
+# foodcritic has been deprecated in favor of cookstyle so we skip the syntax
+# phase now.
+syntax = "echo skipping syntax phase. Use lint phase instead."
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"

--- a/lib/chef-cli/skeletons/code_generator/metadata.rb
+++ b/lib/chef-cli/skeletons/code_generator/metadata.rb
@@ -1,8 +1,7 @@
-# ~FC067 ~FC065 ~FC064
 name             'code_generator'
 maintainer       'Chef Software, Inc.'
 maintainer_email 'dev@chef.io'
 license          'Apache-2.0'
-description      'Generates Chef code for Chef DK'
+description      'Generates Chef code for Chef CLI'
 version          '0.1.0'
-chef_version     '>= 13.0'
+chef_version     '>= 14.0'

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -197,11 +197,9 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
               [local_phases]
               unit = "chef exec rspec spec/"
               lint = "chef exec cookstyle"
-              # Foodcritic includes rules only appropriate for community cookbooks
-              # uploaded to Supermarket. We turn off any rules tagged "supermarket"
-              # by default. If you plan to share this cookbook you should remove
-              # '-t ~supermarket' below to enable supermarket rules.
-              syntax = "chef exec foodcritic . -t ~supermarket"
+              # foodcritic has been deprecated in favor of cookstyle so we skip the syntax
+              # phase now.
+              syntax = "echo skipping syntax phase. Use lint phase instead."
               provision = "chef exec kitchen create"
               deploy = "chef exec kitchen converge"
               smoke = "chef exec kitchen verify"


### PR DESCRIPTION
Foodcritic has been replaced with Cookstyle. We shouldn't recommend folks use Foodcritic in their CI for cookbooks anymore. Anyone generating cookbooks with this will be on a modern Workstation that also includes the new cookstyle.

Signed-off-by: Tim Smith <tsmith@chef.io>