### PR TITLE
new include_policies not added to lock on 'chef update'

### DIFF
--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -147,8 +147,10 @@ module ChefCLI
       end
 
       def prepare_constraints_for_policies
+        # Ensure we recompute policies from their (possibly updated) source
         Policyfile::LockApplier
           .new(policyfile_lock, policyfile_compiler)
+          .with_unlocked_policies(:all)
           .apply!
       end
 

--- a/lib/chef-cli/policyfile_services/update_attributes.rb
+++ b/lib/chef-cli/policyfile_services/update_attributes.rb
@@ -102,7 +102,9 @@ module ChefCLI
       end
 
       def prepare_constraints
+        # Ensure we recompute policies from their (possibly updated) source
         Policyfile::LockApplier.new(policyfile_lock, policyfile_compiler)
+          .with_unlocked_policies(:all)
           .apply!
       end
     end

--- a/spec/unit/policyfile_services/update_attributes_spec.rb
+++ b/spec/unit/policyfile_services/update_attributes_spec.rb
@@ -176,7 +176,7 @@ describe ChefCLI::PolicyfileServices::UpdateAttributes do
           expect(ChefCLI::Policyfile::LockApplier).to receive(:new).with(
             update_attrs_service.policyfile_lock, update_attrs_service.policyfile_compiler
           ).and_return(lock_applier)
-          expect(lock_applier).not_to receive(:with_unlocked_policies)
+          expect(lock_applier).to receive(:with_unlocked_policies).with(:all).and_return(lock_applier)
           expect(lock_applier).to receive(:apply!)
 
           update_attrs_service.run


### PR DESCRIPTION
## Description
Fixes https://github.com/chef/chef-cli/issues/36 - see that issue for repro

The issue is that when a new `include_policies` policy is added the existing lock file does not have reference to it, which causes the `undefined method `[]' for nil:NilClass` error.

The [RFC](https://github.com/chef-boneyard/chef-rfc/pull/280/files#diff-15c933a7d5e3031b363ffd940133a070R95) says:


> The principal potential issue with this approach is that because we are pulling Policyfile elements from a number of included cookbooks, it is necessary for all included policy Lockfiles to be re-scanned upon regeneration of the parent Policyfile, so that the full set of Policyfile elements can be examined and merged. Although using the `git` source to include Policies will mean that the same commit SHA is used every time to rescan the included Lockfile and the `server` source will always ensure the same revision ID is used, when the `local` source is used we have to use whatever the current Lockfile present on disk is. This means that we cannot guarantee it has not changed since the last time it was scanned.

That makes me think that the logic around what policies are updated is incorrect. The logic as it is currently written seems to look for only existing policies in the lock file to update (`policy.apply_locked_source_options`).

Maybe the `unlocked_policies` list was meant to help cover this use case? It is never referenced other than in tests though.

The code as it is currently written will correctly merge attributes from `include_policies` policyfiles. But if `unlocked_policies` is not used it seems like we may be able to simplify this class to just update all `include_policies`. This error is hit during operation of the `update_attributes` so we need to ensure 1) updated attributes from included policyfiles are correctly merged and 2) proper add/update/delete logic is performed for `include_policies` in the updated lock file. There is a `chef update --attributes` flag that is intended to only update attributes and that case needs to be handled as well.

## Related Issue
Fixes https://github.com/chef/chef-cli/issues/36

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
