### PR TITLE
Remove the instance_eval from the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,3 @@ group :development do
   gem "pry-stack_explorer"
   gem "rb-readline"
 end
-
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")


### PR DESCRIPTION
This allows dependabot to parse it.

Signed-off-by: Tim Smith <tsmith@chef.io>