### PR TITLE
Replace usage of deprecated Net::HTTPServerException error class

### DIFF
--- a/lib/chef-cli/policyfile/uploader.rb
+++ b/lib/chef-cli/policyfile/uploader.rb
@@ -79,7 +79,7 @@ module ChefCLI
 
       def data_bag_create
         http_client.post("data", { "name" => COMPAT_MODE_DATA_BAG_NAME })
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException => e
         raise e unless e.response.code == "409"
       end
 
@@ -214,7 +214,7 @@ module ChefCLI
 
       def upload_lockfile_as_data_bag_item(policy_id, data_item)
         http_client.put("data/#{COMPAT_MODE_DATA_BAG_NAME}/#{policy_id}", data_item)
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException => e
         raise e unless e.response.code == "404"
 
         http_client.post("data/#{COMPAT_MODE_DATA_BAG_NAME}", data_item)

--- a/lib/chef-cli/policyfile_services/rm_policy.rb
+++ b/lib/chef-cli/policyfile_services/rm_policy.rb
@@ -134,7 +134,7 @@ module ChefCLI
       def fetch_policy_revision_data
         @policy_revision_data = http_client.get("/policies/#{policy_name}")
         @policy_exists = true
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException => e
         raise unless e.response.code == "404"
 
         @policy_exists = false

--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -319,14 +319,14 @@ describe ChefCLI::Policyfile::Uploader do
 
       it "does not error when the 'policyfiles' data bag exists" do
         response = double("Net::HTTP response", code: "409")
-        error = Net::HTTPServerException.new("conflict", response)
+        error = Net::HTTPClientException.new("conflict", response)
         expect(http_client).to receive(:post).with("data", { "name" => "policyfiles" }).and_raise(error)
         expect { uploader.data_bag_create }.to_not raise_error
       end
 
       it "uploads the policyfile as a data bag item" do
         response = double("Net::HTTP response", code: "404")
-        error = Net::HTTPServerException.new("Not Found", response)
+        error = Net::HTTPClientException.new("Not Found", response)
         expect(http_client).to receive(:put)
           .with("data/policyfiles/example-unit-test", policyfile_as_data_bag_item)
           .and_raise(error)

--- a/spec/unit/policyfile_services/clean_policies_spec.rb
+++ b/spec/unit/policyfile_services/clean_policies_spec.rb
@@ -211,6 +211,8 @@ describe ChefCLI::PolicyfileServices::CleanPolicies do
           end
 
           it "deletes what it can, then raises an error" do
+            # Ruby 2.6 deprecated HTTPServerException but the errors are still initialized using it, so
+            # this will continue to print that out until they remove HTTPServerException
             expected_message = <<~ERROR
               Failed to delete some policy revisions:
               - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPServerException 403 \"Unauthorized\"

--- a/spec/unit/service_exception_inspectors/http_spec.rb
+++ b/spec/unit/service_exception_inspectors/http_spec.rb
@@ -64,7 +64,7 @@ describe ChefCLI::ServiceExceptionInspectors::HTTP do
   end
 
   let(:exception) do
-    Net::HTTPServerException.new(message, response).tap { |e| e.chef_rest_request = request }
+    Net::HTTPClientException.new(message, response).tap { |e| e.chef_rest_request = request }
   end
 
   subject(:inspector) { described_class.new(exception) }


### PR DESCRIPTION
## Description
Porting https://github.com/chef/chef-dk/pull/2182 to chef-cli

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
