### PR TITLE
Improve how we test the gem / add Ruby 2.7 testing

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# This script runs a passed in command, but first setups up the bundler caching on the repo
+
+set -ue
+
+export USER="root"
+
+echo "--- dependencies"
+export LANG=C.UTF-8 LANGUAGE=C.UTF-8
+S3_URL="s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}"
+
+pull_s3_file() {
+    aws s3 cp "${S3_URL}/$1" "$1" || echo "Could not pull $1 from S3"
+}
+
+push_s3_file() {
+    if [ -f "$1" ]; then
+        aws s3 cp "$1" "${S3_URL}/$1" || echo "Could not push $1 to S3 for caching."
+    fi
+}
+
+apt-get update -y
+apt-get install awscli -y
+
+echo "--- bundle install"
+pull_s3_file "bundle.tar.gz"
+pull_s3_file "bundle.sha256"
+
+if [ -f bundle.tar.gz ]; then
+  tar -xzf bundle.tar.gz
+fi
+
+if [ -n "${RESET_BUNDLE_CACHE:-}" ]; then
+    rm bundle.sha256
+fi
+
+bundle config --local path vendor/bundle
+bundle install --jobs=7 --retry=3
+
+echo "--- bundle cache"
+if test -f bundle.sha256 && shasum --check bundle.sha256 --status; then
+    echo "Bundled gems have not changed. Skipping upload to s3"
+else
+    echo "Bundled gems have changed. Uploading to s3"
+    shasum -a 256 Gemfile.lock > bundle.sha256
+    tar -czf bundle.tar.gz vendor/
+    push_s3_file bundle.tar.gz
+    push_s3_file bundle.sha256
+fi
+
+echo "+++ bundle exec task"
+bundle exec $1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -43,7 +43,7 @@ steps:
 - label: run-specs-windows
   command:
     - bundle install --jobs=7 --retry=3 --without docs development
-    - bundle exec rake spec
+    - bundle exec rspec
   expeditor:
     executor:
       docker:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,47 +2,43 @@
 expeditor:
   defaults:
     buildkite:
+      retry:
+        automatic:
+          limit: 1
       timeout_in_minutes: 30
 
 steps:
 - label: run-specs-ruby-2.4
   command:
-    - bundle install --jobs=7 --retry=3 --without docs development
-    - export USER="root"
-    - bundle exec rspec
+    - .expeditor/run_linux_tests.sh rspec
   expeditor:
     executor:
       docker:
-        image: ruby:2.4-stretch
+        image: ruby:2.4-buster
+
 - label: run-specs-ruby-2.5
   command:
-    - bundle install --jobs=7 --retry=3 --without docs development
-    - export USER="root"
-    - bundle exec rspec
+    - .expeditor/run_linux_tests.sh rspec
   expeditor:
     executor:
       docker:
-        image: ruby:2.5-stretch
+        image: ruby:2.5-buster
 
 - label: run-specs-ruby-2.6
   command:
-    - export USER="root"
-    - bundle install --jobs=7 --retry=3 --without docs development
-    - bundle exec rspec
+    - .expeditor/run_linux_tests.sh rspec
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: ruby:2.6-buster
 
-- label: run-specs-ruby-2.6
+- label: run-specs-ruby-2.7
   command:
-    - export USER="root"
-    - bundle install --jobs=7 --retry=3 --without docs development
-    - bundle exec rspec
+    - .expeditor/run_linux_tests.sh rspec
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: ruby:2.7-buster
 
 - label: run-specs-windows
   command:
@@ -55,20 +51,16 @@ steps:
 
 - label: cookstyle-generator-cb-tests-ruby-2.6
   command:
-    - export USER="root"
-    - bundle install --jobs=7 --retry=3 --without docs development
-    - bundle exec rake style:cookstyle
+    - .expeditor/run_linux_tests.sh "rake style:cookstyle"
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: ruby:2.6-buster
 
 - label: chefstyle-tests-ruby-2.6
   command:
-    - export USER="root"
-    - bundle install --jobs=7 --retry=3 --without docs development
-    - bundle exec rake style:chefstyle
+    - .expeditor/run_linux_tests.sh "rake style:chefstyle"
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: ruby:2.6-buster

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/lib/chef-cli/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/build_cookbook.rb
@@ -11,13 +11,13 @@ directory dot_delivery_dir
 
 cookbook_file config_json do
   source 'delivery-config.json'
-  not_if { File.exist?(config_json) }
+  not_if { ::File.exist?(config_json) }
 end
 
 # Adding the delivery local-mode config
 cookbook_file project_toml do
   source 'delivery-project.toml'
-  not_if { File.exist?(project_toml) }
+  not_if { ::File.exist?(project_toml) }
 end
 
 generator_desc('Ensuring correct Workflow (Delivery) build cookbook content')

--- a/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
@@ -129,7 +129,7 @@ unless context.enable_workflow
   # Adding the delivery local-mode config
   cookbook_file "#{cookbook_dir}/.delivery/project.toml" do
     source 'delivery-project.toml'
-    not_if { File.exist?("#{cookbook_dir}/.delivery/project.toml") }
+    not_if { ::File.exist?("#{cookbook_dir}/.delivery/project.toml") }
   end
 end
 

--- a/lib/chef-cli/skeletons/code_generator/recipes/repo.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/repo.rb
@@ -60,7 +60,7 @@ if context.have_git
     execute('initialize-git') do
       command('git init .')
       cwd repo_dir
-      not_if { File.exist?("#{repo_dir}/.gitignore") }
+      not_if { ::File.exist?("#{repo_dir}/.gitignore") }
     end
   end
   template "#{repo_dir}/.gitignore" do

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2020 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -269,7 +269,7 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
               # Cookbook:: build_cookbook
               # Recipe:: publish
               #
-              # Copyright:: 2019, The Authors, All Rights Reserved.
+              # Copyright:: #{DateTime.now.year}, The Authors, All Rights Reserved.
 
               include_recipe 'delivery-truck::publish'
             CONFIG_DOT_JSON

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -22,7 +22,7 @@ require "shared/fixture_cookbook_checksums"
 require "chef-cli/policyfile/storage_config"
 require "chef-cli/policyfile_lock.rb"
 
-describe ChefCLI::PolicyfileLock, "building a lockfile" do
+describe ChefCLI::PolicyfileLock, "building a lockfile", :skip_on_windows do
 
   include_context "fixture cookbooks checksums"
 


### PR DESCRIPTION
- Remove the github lock file. These blow up e-mail boxes and make it harder for casual contributors to get involved
- Add Ruby 2.7 testing
- Use gem caching on the Linux tests to speed up test time
- Test on Debian Buster instead of Stretch (10 vs 9)
- Fix Windows specs to actually run. They weren't doing anything before. This did require turning off the lock specs as windows is generating different SHAs than Linux, which is *probably* a line ending issue.

Signed-off-by: Tim Smith <tsmith@chef.io>