### PR TITLE
WIP: Run knife rehash each time we install a gem

### DIFF
--- a/lib/chef-cli/command/gem.rb
+++ b/lib/chef-cli/command/gem.rb
@@ -32,7 +32,7 @@ module ChefCLI
 
       option :skip_rehash,
         long:        "--skip-rehash",
-        description: "Don't run rehash the cache of knife plugins after running the gem command.",
+        description: "Don't rehash the cache of knife plugins after running the gem command.",
         default:     false
 
       def run(params)

--- a/lib/chef-cli/command/gem.rb
+++ b/lib/chef-cli/command/gem.rb
@@ -42,7 +42,7 @@ module ChefCLI
         unless skip_rehash?
           Chef::Knife::SubcommandLoader.write_hash(Chef::Knife::SubcommandLoader.generate_hash)
 
-          ui.msg "Regeneated cache of knife subcommands at #{Chef::Knife::SubcommandLoader.plugin_manifest_path}. Delete this file to disable the caching."
+          ui.msg "Regenerated cache of knife subcommands at #{Chef::Knife::SubcommandLoader.plugin_manifest_path}. Delete this file to disable the caching."
         end
 
         exit( e.exit_code )

--- a/lib/chef-cli/command/gem.rb
+++ b/lib/chef-cli/command/gem.rb
@@ -21,6 +21,7 @@ require "rubygems" unless defined?(Gem)
 require "rubygems/gem_runner"
 require "rubygems/exceptions"
 require "pp" unless defined?(PP)
+require "chef/knife/core/subcommand_loader"
 
 module ChefCLI
   module Command
@@ -29,17 +30,51 @@ module ChefCLI
     class GemForwarder < ChefCLI::Command::Base
       banner "Usage: #{ChefCLI::Dist::EXEC} gem GEM_COMMANDS_AND_OPTIONS"
 
+      option :skip_rehash,
+        long:        "--skip-rehash",
+        description: "Don't run rehash the cache of knife plugins after running the gem command.",
+        default:     false
+
       def run(params)
-        retval = Gem::GemRunner.new.run( params.clone )
+        retval = Gem::GemRunner.new.run( sanitized_params(params.clone) )
         retval.nil? ? true : retval
-      rescue Gem::SystemExitException => e
+      rescue Gem::SystemExitException => e # yes we're using a rescue for flow control. :(
+        unless skip_rehash?
+          Chef::Knife::SubcommandLoader.write_hash(Chef::Knife::SubcommandLoader.generate_hash)
+
+          ui.msg "Regeneated cache of knife subcommands at #{Chef::Knife::SubcommandLoader.plugin_manifest_path}. Delete this file to disable the caching."
+        end
+
         exit( e.exit_code )
+      end
+
+      #
+      # has the :skip_rehash config option been passed?
+      #
+      # @return [Boolean]
+      def skip_rehash?
+        !!config[:skip_rehash]
+      end
+
+      #
+      # remove the skip-rehash cli flag so we can pass all other flags to the gem command
+      #
+      # @param [Array] cli_params cli params passed to the command
+      #
+      # @returns [Array] sanitized params
+      def sanitized_params(cli_params)
+        cli_params - ["--skip-rehash"]
       end
 
       # Lazy solution: By automatically returning false, we force ChefCLI::Base to
       # call this class' run method, so that Gem::GemRunner can handle the -v flag
       # appropriately (showing the gem version, or installing a specific version
       # of a gem).
+      #
+      # @param [Array] params
+      #
+      # @return [FalseClass]
+      #
       def needs_version?(params)
         false
       end


### PR DESCRIPTION
knife rehash greatly speeds up the performance of knife by caching the location of all knife plugins in the .chef directory. With this change we'll rehash the list any time someone installs a gem into chef, as they may be installing a knife plugin.

Note: This is going to require changes to the subcommand loader that aren't yet in master of chef/chef so we'll be depending on a specific new chef version in the gemspec if we merge this.

Signed-off-by: Tim Smith <tsmith@chef.io>