### PR TITLE
recognize .yml as a valid recipe extension

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -8,22 +8,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
-- label: run-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,6 @@ Layout/TrailingWhitespace:
 Style/PercentLiteralDelimiters:
   Exclude:
     - "lib/chef-cli/skeletons/**/*"
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Exclude:
     - "spec/unit/fixtures/**/*"

--- a/lib/chef-cli/command/describe_cookbook.rb
+++ b/lib/chef-cli/command/describe_cookbook.rb
@@ -87,7 +87,7 @@ module ChefCLI
         remaining_args = parse_options(params)
         if remaining_args.size != 1
           ui.err(opt_parser)
-          return false
+          false
         else
           @cookbook_path = File.expand_path(remaining_args.first)
           true

--- a/lib/chef-cli/command/generator_commands/policyfile.rb
+++ b/lib/chef-cli/command/generator_commands/policyfile.rb
@@ -76,7 +76,7 @@ module ChefCLI
             if chef_repo_mode?
               err("ERROR: You must give a policy name when generating a policy in a chef-repo.")
               @params_valid = false
-              return false
+              false
             else
               use_default_policy_settings
             end
@@ -85,7 +85,7 @@ module ChefCLI
           else
             @params_valid = false
             err("ERROR: too many arguments")
-            return false
+            false
           end
         end
 

--- a/lib/chef-cli/command/install.rb
+++ b/lib/chef-cli/command/install.rb
@@ -110,7 +110,7 @@ module ChefCLI
         remaining_args = parse_options(params)
         if remaining_args.size > 1
           ui.err(opt_parser)
-          return false
+          false
         else
           @policyfile_relative_path = remaining_args.first
           true

--- a/lib/chef-cli/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-cli/policyfile/cookbook_location_specification.rb
@@ -125,7 +125,8 @@ module ChefCLI
 
       def cookbook_has_recipe?(recipe_name)
         expected_path = cookbook_path.join("recipes/#{recipe_name}.rb")
-        expected_path.exist?
+        expected_path_yml = cookbook_path.join("recipes/#{recipe_name}.yml")
+        expected_path.exist? || expected_path_yml.exist?
       end
 
       def cached_cookbook

--- a/lib/chef-cli/policyfile/lock_fetcher_mixin.rb
+++ b/lib/chef-cli/policyfile/lock_fetcher_mixin.rb
@@ -24,9 +24,9 @@ module ChefCLI
         expected_id = source_options[:policy_revision_id]
         if expected_id
           if included_id.eql?(expected_id) # are they the same?
-            return
+            nil
           elsif included_id[0, 10].eql?(expected_id) # did they use the 10 char substring
-            return
+            nil
           else
             raise ChefCLI::InvalidLockfile, "Expected policy_revision_id '#{expected_id}' does not match included_policy '#{included_id}'."
           end

--- a/spec/unit/policyfile/cookbook_location_specification_spec.rb
+++ b/spec/unit/policyfile/cookbook_location_specification_spec.rb
@@ -143,10 +143,14 @@ describe ChefCLI::Policyfile::CookbookLocationSpecification do
       allow(cookbook_location_spec).to receive(:cookbook_path).and_return(cookbook_path)
 
       default_recipe_path = install_path.join("recipes/default.rb")
+      default_yml_recipe_path = install_path.join("recipes/default.yml")
       nope_recipe_path = install_path.join("recipes/nope.rb")
+      nope_yml_recipe_path = install_path.join("recipes/nope.yml")
 
       expect(cookbook_path).to receive(:join).with("recipes/default.rb").and_return(default_recipe_path)
+      expect(cookbook_path).to receive(:join).with("recipes/default.yml").and_return(default_yml_recipe_path)
       expect(cookbook_path).to receive(:join).with("recipes/nope.rb").and_return(nope_recipe_path)
+      expect(cookbook_path).to receive(:join).with("recipes/nope.yml").and_return(nope_yml_recipe_path)
 
       expect(default_recipe_path).to receive(:exist?).and_return(true)
       expect(nope_recipe_path).to receive(:exist?).and_return(false)

--- a/spec/unit/policyfile/cookbook_location_specification_spec.rb
+++ b/spec/unit/policyfile/cookbook_location_specification_spec.rb
@@ -154,6 +154,7 @@ describe ChefCLI::Policyfile::CookbookLocationSpecification do
 
       expect(default_recipe_path).to receive(:exist?).and_return(true)
       expect(nope_recipe_path).to receive(:exist?).and_return(false)
+      expect(nope_yml_recipe_path).to receive(:exist?).and_return(false)
 
       expect(cookbook_location_spec.cookbook_has_recipe?("default")).to be(true)
       expect(cookbook_location_spec.cookbook_has_recipe?("nope")).to be(false)


### PR DESCRIPTION
Signed-off-by: Nick Rycar <nickrycar@Nicks-MacBook-Pro.local>

Updates the `cookbook_has_recipe?` function such that it will recognize either `.rb` or `.yml` as a valid recipe extension.

## Description
Pretty much just that! Added a variable and an or operator, and I think that did the trick. 

Not sure what formal testing looks like these days, but to validate:
- ran `chef install` on a sample yml-based cookbook, and received a "ChefCLI::CookbookDoesNotContainRequiredRecipe" error.
- I ran `bundle install` on my test branch, and vendored to a local directory
- ran `bundle exec chef install /PATH/TO/COOKBOOK/Policyfile.rb` and successfully created a lock.
 
## Related Issue
#62 - Support for YAML Recipes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
