### PR TITLE
Add a ChefZeroCapture kitchen provisioner

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", ">= 1", "< 3"
   gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
+  gem.add_development_dependency "test-kitchen", "> 2.5"
 end

--- a/lib/kitchen/provisioner/chef_zero_capture.rb
+++ b/lib/kitchen/provisioner/chef_zero_capture.rb
@@ -1,0 +1,90 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Marc Paradise <marc@chef.io>
+#
+# Copyright (C) 2020, Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "json"
+require "kitchen"
+require "kitchen/provisioner/base"
+require "kitchen/provisioner/chef_zero"
+
+module Kitchen
+  module Provisioner
+    # For use in a provisioner that does not do any run list evaluation or
+    # policy/berks file expansion.
+    class ChefZeroCaptureSandbox < Chef::CommonSandbox
+      def populate
+        super
+        prepare(:policies)
+        prepare(:policy_groups)
+        prepare(:cookbook_artifacts)
+      end
+
+      # Override #prepare_cookbooks because we don't want any cookbook resolving to occur
+      # via kitchen through berks, policy
+      def prepare_cookbooks
+        cp_cookbooks
+        filter_only_cookbook_files
+      end
+    end
+
+    # chef-zero provisioner intended for use with `chef capture`.
+    #
+    # This provisioner does not do any cookbook dependency
+    # resolution and will not pull in external cookbooks.  All cookbooks
+    # or cookbook artificats  + policy data as captured from the live node and are
+    # expected to be available for chef-zero to provide to the client.
+    class ChefZeroCapture < ChefZero
+      # Declaring these ensure that they're available to the sandbox - it's initialized
+      # the provider's configoptions.
+      default_config :policies_path, "policies"
+      default_config :policy_groups_path, "policy_groups"
+      default_config :cookbook_artifacts_path, "cookbook_artifacts"
+
+      # This will load policyfile/berkshelf.  We don't want either - the client resolves all
+      # dependencies from chef-zero, exactly as preppped in the captured repository.
+      def load_needed_dependencies!; end
+
+      def create_sandbox
+        # We have to invoke the the true Base create_sandbox because it does setup that
+        # we want. However, we do not want to invoke the create_sandbox inherited from
+        # ChefZero/ChefBase - those will create and populate a ChefCommonSandbox instead
+        # of a ChefZeroCaptureSandbox.
+        m = Base.instance_method(:create_sandbox).bind(self)
+        m.call
+
+        # These behaviors from super we _do_ want, so we need to copy them here.
+        prepare_validation_pem
+        prepare_config_rb
+        ChefZeroCaptureSandbox.new(config, sandbox_path, instance).populate
+      end
+
+      # Overriding the private ProviderChefZero#default_config_rb
+      # so that we can add additional configuratoin required for  chef-zeor
+      # to be able to locate our policies/, policy groups, and cookbook artifacts
+      # at run-time.
+      def default_config_rb
+        cfg = super
+        # Need to tell chef-zero about our additional config.
+        root = config[:root_path].gsub("$env:TEMP", "\#{ENV['TEMP']\}")
+        cfg[:policies_path] = remote_path_join(root, config[:policies_path])
+        cfg[:policy_groups_path] = remote_path_join(root, config[:policy_groups_path])
+        cfg[:cookbook_artifacts_path] = remote_path_join(root, config[:cookbook_artifacts_path])
+        cfg
+      end
+    end
+  end
+end

--- a/spec/unit/kitchen/provisioner/chef_zero_capture_spec.rb
+++ b/spec/unit/kitchen/provisioner/chef_zero_capture_spec.rb
@@ -1,0 +1,84 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Marc Paradsie <marc.paradise@gmail.com>
+#
+# Copyright (C) 2020 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../../spec_helper"
+
+require "kitchen"
+require "kitchen/provisioner/chef_zero_capture"
+
+describe Kitchen::Provisioner::ChefZeroCapture do
+  let(:logged_output)   { StringIO.new }
+  let(:logger)          { Logger.new(logged_output) }
+  let(:kitchen_root) { Dir.mktmpdir }
+
+  let(:config) do
+    { test_base_path: "/t", base_path: "/b", kitchen_root: kitchen_root, root_path: kitchen_root }
+  end
+  let(:platform)        { double("platform", os_type: nil) }
+  let(:suite)           { double("suite", name: "fried") }
+
+  let(:instance_config) do
+    double("config", name: "coolbeans", logger: logger, suite: suite, platform: platform)
+  end
+
+  subject do
+    p = Kitchen::Provisioner::ChefZeroCapture.new(config)
+    p.finalize_config!(instance_config)
+  end
+
+  after do
+    FileUtils.remove_entry(kitchen_root)
+  end
+
+  describe "#create_sandbox" do
+    let(:sandbox_mock) do
+      double("sandbox", populate: nil)
+    end
+    before do
+      allow(Kitchen::Provisioner::ChefZeroCaptureSandbox).to receive(:new).and_return sandbox_mock
+    end
+
+    it "initializes files and populates a ChefZeroCaptureSandbox" do
+      expect(subject).to receive(:prepare_validation_pem)
+      expect(subject).to receive(:prepare_config_rb)
+      expect(sandbox_mock).to receive(:populate)
+      subject.create_sandbox
+    end
+
+    after do
+      begin
+        subject.cleanup_sandbox
+      rescue # rubocop:disable Lint/HandleExceptions
+      end
+    end
+  end
+
+  describe "#default_config_rb" do
+    it "contains keys that suggest 'super' was invoked for full config_rb setup" do
+      cfg = subject.default_config_rb
+      expect(cfg[:node_path]).to eq File.join(kitchen_root, "nodes")
+    end
+
+    it "adds the expected correct config for captured nodes" do
+      cfg = subject.default_config_rb
+      expect(cfg[:policies_path]).to eq File.join(kitchen_root, "policies")
+      expect(cfg[:cookbook_artifacts_path]).to eq File.join(kitchen_root, "cookbook_artifacts")
+      expect(cfg[:policy_groups_path]).to eq File.join(kitchen_root, "policy_groups")
+    end
+  end
+end


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This provisioner makes a `chef capture`d node's
dependencies fully available to chef-zero by adding
support for policies, policy_groups, and cookbook_artifacts
to the provisioner.

This allows policy-managed nodes captured with `chef capture` to converge
in the same way as they do when running in their normal enviornment
without the kitchen provisioner performing any policyfile resolution
ahead of time.

This provisioner is only suitable for use with a `capture`d node; in the normal case, 
a node using chef-zero will want the current behavior of resolving policyfiles/berksfiles. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
