### PR TITLE
Pin ffi gem to less than 1.13.0

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -51,4 +51,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "paint", ">= 1", "< 3"
   gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
   gem.add_development_dependency "test-kitchen", "> 2.5"
+  gem.add_dependency "ffi", "< 1.13"
 end


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

Currently, there is a known issue in the ffi gem version 1.13.0 that causes an issue on Windows. This pins the version in the chef-cli to a lesser version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
