### PR TITLE
Revert Ruby requirements to allow for 2.5 or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -35,7 +35,16 @@ steps:
       docker:
         image: ruby:2.7-buster
 
-- label: run-specs-windows
+- label: run-specs-windows-2.6
+  command:
+    - powershell .expeditor/run_windows_tests.ps1 rspec
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        image: rubydistros/windows-2019:2.6
+
+- label: run-specs-windows-2.7
   command:
     - powershell .expeditor/run_windows_tests.ps1 rspec
   expeditor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,6 +11,22 @@ expeditor:
 
 steps:
 
+- label: run-specs-ruby-2.5
+  command:
+    - .expeditor/run_linux_tests.sh rspec
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.5-buster
+
+- label: run-specs-ruby-2.6
+  command:
+    - .expeditor/run_linux_tests.sh rspec
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.6-buster
+
 - label: run-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rspec

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :test do
   gem "rspec-mocks", "~> 3.8"
   gem "cookstyle"
   gem "chefstyle"
+  gem "test-kitchen", "> 2.5"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ group :test do
   gem "cookstyle"
   gem "chefstyle"
   gem "test-kitchen", "> 2.5"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+    gem "chef-zero", "~> 14"
+  end
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,13 @@ group :test do
   gem "test-kitchen", "> 2.5"
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "~> 14"
+    gem "chef", "~> 15"
   end
 end
 
 group :development do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer"
+  gem "pry-stack_explorer", "~> 0.4.0"
   gem "rb-readline"
 end

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
   gem.homepage      = "https://www.chef.io/"
 
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.files = %w{Rakefile LICENSE} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
   gem.homepage      = "https://www.chef.io/"
 
-  gem.required_ruby_version = ">= 2.6"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.files = %w{Rakefile LICENSE} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks
@@ -50,6 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", ">= 1", "< 3"
   gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
-  gem.add_development_dependency "test-kitchen", "> 2.5"
   gem.add_dependency "ffi", "< 1.13"
 end

--- a/lib/chef-cli/cli.rb
+++ b/lib/chef-cli/cli.rb
@@ -122,7 +122,13 @@ module ChefCLI
         "Test Kitchen": "kitchen",
         "Cookstyle": "cookstyle",
       }.each do |name, cli|
-        result = Bundler.with_unbundled_env { shell_out("#{cli} --version") }
+        # @todo when Ruby 2.5/2.6 support goes away this if statement can go away
+        if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2")
+          result = Bundler.with_unbundled_env { shell_out("#{cli} --version") }
+        else
+          result = Bundler.with_clean_env { shell_out("#{cli} --version") }
+        end
+
         if result.exitstatus != 0
           msg("#{name} version: ERROR")
         else


### PR DESCRIPTION
We have to be careful with chef-cli since it's a dep of chefspec now.