### PR TITLE
More updates to the generated chefignore file

### DIFF
--- a/lib/chef-cli/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-cli/skeletons/code_generator/files/default/chefignore
@@ -10,10 +10,6 @@ Icon?
 nohup.out
 Thumbs.db
 
-# SASS #
-########
-.sass-cache
-
 # EDITORS #
 ###########
 .#*
@@ -26,11 +22,11 @@ Thumbs.db
 *.tmproj
 *~
 \#*
-mkmf.log
 REVISION
 TAGS*
 tmtags
 .vscode
+.editorconfig
 
 ## COMPILED ##
 ##############
@@ -43,6 +39,7 @@ tmtags
 *.so
 */rdoc/
 a.out
+mkmf.log
 
 # Testing #
 ###########


### PR DESCRIPTION
Remove SAAS stuff. No clue why this was ever in there. Add .editorconfig and move mkmf.log into compiled since that's the log file for compiled gems and has nothing to do with editors.

Signed-off-by: Tim Smith <tsmith@chef.io>