### PR TITLE
Remove the ffi pin now that 1.13.1 is out

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,5 +50,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", ">= 1", "< 3"
   gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
-  gem.add_dependency "ffi", "< 1.13"
 end


### PR DESCRIPTION
We'll exclude 1.13.0 in train so it hits everything

Signed-off-by: Tim Smith <tsmith@chef.io>