### PR TITLE
Update the content of the generated chefignore

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.8"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"
-  gem.add_dependency "diff-lcs", "~> 1.0"
+  gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
   gem.add_dependency "paint", ">= 1", "< 3"
   gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
 end

--- a/lib/chef-cli/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-cli/skeletons/code_generator/files/default/chefignore
@@ -9,6 +9,7 @@ ehthumbs.db
 Icon?
 nohup.out
 Thumbs.db
+.envrc
 
 # EDITORS #
 ###########
@@ -45,17 +46,23 @@ mkmf.log
 ###########
 .circleci/*
 .codeclimate.yml
+.delivery/*
 .foodcritic
 .kitchen*
+.mdlrc
+.overcommit.yml
 .rspec
 .rubocop.yml
 .travis.yml
 .watchr
+.yamllint
 azure-pipelines.yml
+Dangerfile
 examples/*
 features/*
 Guardfile
 kitchen.yml*
+mlc_config.json
 Procfile
 Rakefile
 spec/*
@@ -68,6 +75,7 @@ test/*
 .gitconfig
 .github/*
 .gitignore
+.gitkeep
 .gitmodules
 .svn
 */.bzr/*
@@ -95,10 +103,11 @@ Policyfile.lock.json
 
 # Documentation #
 #############
-CHANGELOG*
-CONTRIBUTING*
-TESTING*
 CODE_OF_CONDUCT*
+CONTRIBUTING*
+documentation/*
+TESTING*
+UPGRADING*
 
 # Vagrant #
 ###########


### PR DESCRIPTION
Add a few files used in all the sous-chefs cookbooks since a lot of people follow their examples and will have those same CI setups. This also removes the changelog since `knife supermarket share` is using the ignore file and that results in cookbooks without a changelog on the supermarket.

Signed-off-by: Tim Smith <tsmith@chef.io>