### PR TITLE
Remove redundant encoding comments

### DIFF
--- a/lib/chef-cli/policyfile_lock.rb
+++ b/lib/chef-cli/policyfile_lock.rb
@@ -1,4 +1,3 @@
-# -*- coding: UTF-8 -*-
 #
 # Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
 # License:: Apache License, Version 2.0

--- a/lib/kitchen/provisioner/chef_zero_capture.rb
+++ b/lib/kitchen/provisioner/chef_zero_capture.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Marc Paradise <marc@chef.io>
 #

--- a/lib/kitchen/provisioner/policyfile_zero.rb
+++ b/lib/kitchen/provisioner/policyfile_zero.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/unit/kitchen/provisioner/chef_zero_capture_spec.rb
+++ b/spec/unit/kitchen/provisioner/chef_zero_capture_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Marc Paradsie <marc.paradise@gmail.com>
 #

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -1,4 +1,3 @@
-# -*- coding: UTF-8 -*-
 #
 # Copyright:: Copyright (c) 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -1,4 +1,3 @@
-# -*- coding: UTF-8 -*-
 #
 # Copyright:: Copyright (c) 2017 Chef Software Inc.
 # License:: Apache License, Version 2.0

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -1,4 +1,3 @@
-# -*- coding: UTF-8 -*-
 #
 # Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
 # License:: Apache License, Version 2.0


### PR DESCRIPTION
The default is utf-8 in Ruby 2+

Signed-off-by: Tim Smith <tsmith@chef.io>