### PR TITLE
Test chef generate cookbook content on each cookstyle release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ group :test do
   gem "rspec", "~> 3.8"
   gem "rspec-expectations", "~> 3.8"
   gem "rspec-mocks", "~> 3.8"
-  gem "cookstyle"
-  gem "chefstyle"
+  gem "cookstyle", "6.12.6" # this forces dependabot PRs to open which triggers cookstyle CI on the chef generate command
+  gem "chefstyle", "1.2.0"
   gem "test-kitchen", "> 2.5"
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "~> 14"


### PR DESCRIPTION
By pinning to the exact version we'll get a PR from dependabot to bump the version each time cookstyle is released. This PR will trigger the cookstyle tests of the `chef generate cookbook` content and we can fix anything before making a workstation release

Signed-off-by: Tim Smith <tsmith@chef.io>