### PR TITLE
Add habitat to version output

### DIFF
--- a/lib/chef-cli/dist.rb
+++ b/lib/chef-cli/dist.rb
@@ -35,5 +35,10 @@ module ChefCLI
 
     # Chef-Zero's product name
     ZERO_PRODUCT = "Chef Infra Zero".freeze
+
+    HAB_PRODUCT = "Chef Habitat".freeze
+    HAB_SOFTWARE_NAME = "habitat".freeze
+
+    HAB_CLI = "hab".freeze
   end
 end


### PR DESCRIPTION
This also adds fallback version resolving, when a component
does not exist as a gem we try to resolve it out of the
package manifest.
Partially handles chef/chef-workstation#1354
Requires chef/chef-workstation#1363 for manifest based version to display correctly. 

Before: 
```
Chef Workstation version: 20.7.96
Chef Infra Client version: 16.2.73
Chef InSpec version: 4.21.3
Chef CLI version: 3.0.11
Test Kitchen version: 2.5.3
Cookstyle version: 6.12.6
```

After: 
```
$ chef --version
Chef Workstation version: 20.7.96
Chef Infra Client version: 16.2.73
Chef InSpec version: 4.21.3
Chef CLI version: 3.0.11
Chef Habitat version: 1.6.56/20200618202635
Test Kitchen version: 2.5.3
Cookstyle version: 6.12.6
```
