### PR TITLE
Use match? when we don't need the match

### DIFF
--- a/lib/chef-cli/command/generator_commands.rb
+++ b/lib/chef-cli/command/generator_commands.rb
@@ -37,7 +37,7 @@ module ChefCLI
         long: "--license LICENSE",
         description: "all_rights, apachev2, mit, gplv2, gplv3 - defaults to all_rights",
         proc: Proc.new { |l|
-          l =~ /apache2/ ? "apachev2" : l
+          /apache2/.match?(l) ? "apachev2" : l
         },
         default: nil
 

--- a/lib/chef-cli/policyfile/dsl.rb
+++ b/lib/chef-cli/policyfile/dsl.rb
@@ -233,7 +233,7 @@ module ChefCLI
             message = "#{run_list_desc} has invalid cookbook name '#{cookbook}'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
 
             # Special case when there's only one colon instead of two:
-            if cookbook =~ /[^:]:[^:]/
+            if /[^:]:[^:]/.match?(cookbook)
               message << "\nDid you mean '#{item.sub(":", "::")}'?"
             end
 


### PR DESCRIPTION
This uses less memory since it returns a boolean instead of the full
match data object.

Signed-off-by: Tim Smith <tsmith@chef.io>