### PR TITLE
Rename sanity_check! method to path_check!

### DIFF
--- a/lib/chef-cli/cli.rb
+++ b/lib/chef-cli/cli.rb
@@ -59,7 +59,7 @@ module ChefCLI
     end
 
     def run(enforce_license: false)
-      sanity_check!
+      path_check!
 
       subcommand_name, *subcommand_params = argv
 
@@ -224,7 +224,7 @@ module ChefCLI
     # catch the cases where users setup only the embedded_bin_dir in their path, or
     # when they have the embedded_bin_dir before the omnibus_bin_dir -- both of which will
     # defeat appbundler and interact very badly with our intent.
-    def sanity_check!
+    def path_check!
       # When installed outside of omnibus, trust the user to configure their PATH
       return true unless omnibus_install?
 

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -55,7 +55,7 @@ describe ChefCLI::CLI do
 
   def run_cli(expected_exit_code)
     expect(cli).to receive(:exit).with(expected_exit_code)
-    expect(cli).to receive(:sanity_check!)
+    expect(cli).to receive(:path_check!)
     cli.run
   end
 
@@ -256,7 +256,7 @@ describe ChefCLI::CLI do
     end
   end
 
-  context "sanity_check!" do
+  context "path_check!" do
 
     before do
       allow(Gem).to receive(:ruby).and_return(ruby_path)


### PR DESCRIPTION
sanity_check does not align with our code of conduct and also is not very descriptive.

Signed-off-by: Tim Smith <tsmith@chef.io>