### PR TITLE
Simplify and speed up how we detect if we're in an omnibus install

### DIFF
--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -53,7 +53,7 @@ module ChefCLI
     # @return [Boolean]
     #
     def omnibus_install?
-      __dir__.start_with?("C:/opscode/", "/opt/")
+      omnibus_embedded_bin_dir.split(File::SEPARATOR)[-2] == 'embedded'
     end
 
     def omnibus_root
@@ -65,7 +65,7 @@ module ChefCLI
     end
 
     def omnibus_embedded_bin_dir
-      @omnibus_embedded_bin_dir ||= omnibus_expand_path(omnibus_root, "embedded", "bin")
+      @omnibus_embedded_bin_dir ||= omnibus_expand_path(Gem.bindir)
     end
 
     def package_home
@@ -134,8 +134,13 @@ module ChefCLI
       dir
     end
 
+    #
+    # The base path of the omnibus install such as /opt/chef-workstation/
+    #
+    # @return [String]
+    #
     def expected_omnibus_root
-      File.expand_path(File.join(Gem.ruby, "..", "..", ".."))
+      File.expand_path(File.join(Gem.bindir, "..", ".."))
     end
 
     def default_package_home

--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -53,8 +53,7 @@ module ChefCLI
     # @return [Boolean]
     #
     def omnibus_install?
-      # https://rubular.com/r/z74Rt0X9m2fJ96
-      __dir__.match?(%r{C:/opscode|/opt/})
+      __dir__.start_with?("C:/opscode/", "/opt/")
     end
 
     def omnibus_root

--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -48,13 +48,13 @@ module ChefCLI
     end
 
     #
-    # Locates the omnibus directories
+    # Are we in an Omnibus install (chef-workstation)
+    #
+    # @return [Boolean]
     #
     def omnibus_install?
-      # We also check if the location we're running from (omnibus_root is relative to currently-running ruby)
-      # includes the version manifest that omnibus packages ship with. If it doesn't, then we're running locally
-      # or out of a gem - so not as an 'omnibus install'
-      File.exist?(expected_omnibus_root) && File.exist?(File.join(expected_omnibus_root, "version-manifest.json"))
+      # https://rubular.com/r/z74Rt0X9m2fJ96
+      __dir__.match?(%r{C:/opscode|/opt/})
     end
 
     def omnibus_root

--- a/spec/unit/command/exec_spec.rb
+++ b/spec/unit/command/exec_spec.rb
@@ -33,22 +33,22 @@ describe ChefCLI::Command::Exec do
 
   describe "when locating omnibus directory" do
     it "should find omnibus bin directory from ruby path" do
-      allow(Gem).to receive(:ruby).and_return(File.join(fixtures_path, "eg_omnibus_dir/valid/embedded/bin/ruby"))
+      allow(Gem).to receive(:bindir).and_return(File.join(fixtures_path, "eg_omnibus_dir/valid/embedded/bin"))
       expect(command_instance.omnibus_bin_dir).to include("eg_omnibus_dir/valid/bin")
     end
 
     it "should find omnibus embedded bin directory from ruby path" do
-      allow(Gem).to receive(:ruby).and_return(File.join(fixtures_path, "eg_omnibus_dir/valid/embedded/bin/ruby"))
+      allow(Gem).to receive(:bindir).and_return(File.join(fixtures_path, "eg_omnibus_dir/valid/embedded/bin"))
       expect(command_instance.omnibus_embedded_bin_dir).to include("eg_omnibus_dir/valid/embedded/bin")
     end
 
     it "should raise OmnibusInstallNotFound if directory is not looking like omnibus" do
-      allow(Gem).to receive(:ruby).and_return(File.join(fixtures_path, ".rbenv/versions/2.1.1/bin/ruby"))
+      allow(Gem).to receive(:bindir).and_return(File.join(fixtures_path, ".rbenv/versions/2.1.1/bin"))
       expect { command_instance.omnibus_bin_dir }.to raise_error(ChefCLI::OmnibusInstallNotFound)
     end
 
     it "should raise OmnibusInstallNotFound if directory is not looking like omnibus" do
-      allow(Gem).to receive(:ruby).and_return(File.join(fixtures_path, ".rbenv/versions/2.1.1/bin/ruby"))
+      allow(Gem).to receive(:bindir).and_return(File.join(fixtures_path, ".rbenv/versions/2.1.1/bin"))
       expect { command_instance.omnibus_embedded_bin_dir }.to raise_error(ChefCLI::OmnibusInstallNotFound)
     end
   end


### PR DESCRIPTION
This gets called at the start of every command to the chef CLI. It involves a bunch of path discover, expansion, and file checks that aren't necessary. We can just take the directory that we're in and see if it starts with our omnibus directory structure. This is significantly faster and uses less memory according to stackprof profiling.

Signed-off-by: Tim Smith <tsmith@chef.io>