### PR TITLE
Minor memory optimizations to `chef generate cookbook` command

### DIFF
--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -215,7 +215,7 @@ module ChefCLI
           @cookbook_name_or_path = arguments[0]
           if !@cookbook_name_or_path
             @params_valid = false
-          elsif /-/ =~ File.basename(@cookbook_name_or_path)
+          elsif File.basename(@cookbook_name_or_path).include?("-")
             msg("Hyphens are discouraged in cookbook names as they may cause problems with custom resources. See https://docs.chef.io/ctl_chef/#chef-generate-cookbook for more information.")
           end
 

--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -205,9 +205,13 @@ module ChefCLI
           result
         end
 
+        #
+        # @param [Pathname] path a directory
+        #
+        # @return [Boolean] delivery cli.toml exists
+        #
         def contains_delivery_cli_toml?(path)
-          delivery_cli_path = path.join(".delivery/cli.toml")
-          delivery_cli_path.exist?
+          path.join(".delivery/cli.toml").exist?
         end
 
         def read_and_validate_params

--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -187,22 +187,21 @@ module ChefCLI
           @verbose
         end
 
+        #
+        # Is there a .delivery/cli.toml in the current dir or any of the parent dirs
+        #
+        # @return [Boolean]
+        #
         def have_delivery_config?
           # delivery-cli's logic is to look recursively upward for
           # .delivery/cli.toml starting from pwd:
           # https://github.com/chef/delivery-cli/blob/22cbef3987ebd0aee98405b7e161a100edc87e49/src/delivery/config/mod.rs#L225-L247
 
-          path_to_check = File.expand_path(Dir.pwd)
-          result = false
-
-          Pathname.new(path_to_check).ascend do |path|
-            if contains_delivery_cli_toml?(path)
-              result = true
-              break
-            end
+          Pathname.new(Dir.pwd).ascend do |path|
+            return true if contains_delivery_cli_toml?(path)
           end
 
-          result
+          false # nothing was found
         end
 
         #


### PR DESCRIPTION
There were a few methods using more memory than they needed to here.