### PR TITLE
Replace paint gem with Pastel

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.8"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"
   gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
-  gem.add_dependency "paint", ">= 1", "< 3"
+  gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
 end

--- a/lib/chef-cli/policyfile/differ.rb
+++ b/lib/chef-cli/policyfile/differ.rb
@@ -17,7 +17,7 @@
 
 require "diff/lcs"
 require "diff/lcs/hunk"
-require "paint"
+require "pastel"
 require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module ChefCLI
@@ -215,9 +215,15 @@ module ChefCLI
         ui.print("\n")
       end
 
+      def pastel
+        @pastel ||= Pastel.new
+      end
+
       def print_color_diff(hunk)
         hunk.to_s.each_line do |line|
-          ui.print(Paint[line, color_for_line(line)])
+          line_color = color_for_line(line)
+          line = pastel.decorate(line, line_color) unless line_color.nil?
+          ui.print(line)
         end
       end
 

--- a/spec/unit/policyfile/differ_spec.rb
+++ b/spec/unit/policyfile/differ_spec.rb
@@ -243,7 +243,7 @@ describe ChefCLI::Policyfile::Differ do
 
   def output
     # ANSI codes make the tests harder to read
-    Paint.unpaint(ui.output)
+    Pastel.new.strip(ui.output)
   end
 
   subject(:differ) do


### PR DESCRIPTION
We already use pastel in several projects. Paint is only used here so we could stop building it with Workstation by making this change.

Signed-off-by: Tim Smith <tsmith@chef.io>