### PR TITLE
Speed up requires when outside omnibus

### DIFF
--- a/lib/chef-cli/cli.rb
+++ b/lib/chef-cli/cli.rb
@@ -178,12 +178,12 @@ module ChefCLI
     end
 
     def manifest_hash
-      require "json"
+      require "json" unless defined?(JSON)
       @manifest_hash ||= JSON.parse(read_version_manifest_json)
     end
 
     def gem_manifest_hash
-      require "json"
+      require "json" unless defined?(JSON)
       @gem_manifest_hash ||= JSON.parse(read_gem_version_manifest_json)
     end
 

--- a/lib/chef-cli/command/env.rb
+++ b/lib/chef-cli/command/env.rb
@@ -21,7 +21,7 @@ require_relative "../ui"
 require_relative "../version"
 require_relative "../dist"
 require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module ChefCLI
   module Command

--- a/lib/chef-cli/command/shell_init.rb
+++ b/lib/chef-cli/command/shell_init.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "erb"
+require "erb" unless defined?(ERB)
 
 require_relative "../commands_map"
 require_relative "../builtin_commands"

--- a/lib/chef-cli/policyfile/artifactory_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/artifactory_cookbook_source.rb
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-require "json"
+require "json" unless defined?(JSON)
 require_relative "../cookbook_omnifetch"
 require_relative "source_uri"
 require_relative "../exceptions"
-require "chef/http/simple"
+require "chef/http/simple" unless defined?(Chef::HTTP::Simple)
 
 module ChefCLI
   module Policyfile

--- a/lib/chef-cli/policyfile/attribute_merge_checker.rb
+++ b/lib/chef-cli/policyfile/attribute_merge_checker.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "chef/mash"
+require "chef/mash" unless defined?(Mash)
 
 module ChefCLI
   module Policyfile

--- a/lib/chef-cli/policyfile/community_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/community_cookbook_source.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "json"
+require "json" unless defined?(JSON)
 require_relative "../cookbook_omnifetch"
 require_relative "../exceptions"
 require "chef/http/simple"

--- a/lib/chef-cli/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-cli/policyfile/cookbook_location_specification.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "semverse"
+require "semverse" unless defined?(Semverse)
 require_relative "../cookbook_omnifetch"
 require_relative "storage_config"
 

--- a/lib/chef-cli/policyfile/delivery_supermarket_source.rb
+++ b/lib/chef-cli/policyfile/delivery_supermarket_source.rb
@@ -16,9 +16,7 @@
 #
 
 require "forwardable" unless defined?(Forwardable)
-
-require "semverse"
-
+require "semverse" unless defined?(Semverse)
 require_relative "community_cookbook_source"
 
 module ChefCLI

--- a/lib/kitchen/provisioner/chef_zero_capture.rb
+++ b/lib/kitchen/provisioner/chef_zero_capture.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "json"
+require "json" unless defined?(JSON)
 require "kitchen"
 require "kitchen/provisioner/base"
 require "kitchen/provisioner/chef_zero"

--- a/spec/unit/command/env_spec.rb
+++ b/spec/unit/command/env_spec.rb
@@ -16,7 +16,7 @@
 #
 
 require "spec_helper"
-require "yaml"
+require "yaml" unless defined?(YAML)
 require "chef-cli/command/env"
 
 describe ChefCLI::Command::Env do

--- a/spec/unit/fixtures/cookbooks_api/update_fixtures.rb
+++ b/spec/unit/fixtures/cookbooks_api/update_fixtures.rb
@@ -1,6 +1,6 @@
 require "openssl"
 require "net/https"
-require "json"
+require "json" unless defined?(JSON)
 require "pp"
 require "uri"
 


### PR DESCRIPTION
We patch Ruby in omnibus, but outside Omnibus these requires can be slow. This will speed up any pipelines using the gem directly or any of our test suites.

Signed-off-by: Tim Smith <tsmith@chef.io>