### PR TITLE
Require net/http not net/https

### DIFF
--- a/spec/unit/fixtures/cookbooks_api/update_fixtures.rb
+++ b/spec/unit/fixtures/cookbooks_api/update_fixtures.rb
@@ -1,5 +1,5 @@
 require "openssl"
-require "net/https"
+require "net/http" unless defined?(Net::HTTP)
 require "json" unless defined?(JSON)
 require "pp"
 require "uri"

--- a/spec/unit/service_exception_inspectors/http_spec.rb
+++ b/spec/unit/service_exception_inspectors/http_spec.rb
@@ -16,7 +16,7 @@
 #
 
 require "spec_helper"
-require "net/http"
+require "net/http" unless defined?(Net::HTTP)
 require "chef/monkey_patches/net_http"
 require "chef-cli/service_exception_inspectors/http"
 


### PR DESCRIPTION
net/https just requires net/http and openssl. Let's just do that ourselves

Signed-off-by: Tim Smith <tsmith@chef.io>