### PR TITLE
Chef install now works when lockfile alone exists  #1292

### DIFF
--- a/lib/chef-cli/policyfile/storage_config.rb
+++ b/lib/chef-cli/policyfile/storage_config.rb
@@ -52,7 +52,7 @@ module ChefCLI
           return use_policyfile_lock(policyfile_filename)
         end
         unless policyfile_filename.end_with?(".rb")
-          raise InvalidPolicyfileFilename, "Policyfile filenames must end with `.rb' extension (you gave: `#{policyfile_filename}')"
+          raise InvalidPolicyfileFilename, "Policyfile filenames must end with an `.rb' or `.lock.json' extension (you gave: `#{policyfile_filename}')"
         end
 
         @policyfile_filename = policyfile_filename

--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -42,8 +42,8 @@ module ChefCLI
         @overwrite = overwrite
         @chef_config = config
 
-        policyfile_rel_path = policyfile || "Policyfile.rb"
-        policyfile_full_path = File.expand_path(policyfile_rel_path, root_dir)
+        @policyfile_rel_path = policyfile || "Policyfile.rb"
+        policyfile_full_path = File.expand_path(@policyfile_rel_path, root_dir)
         @storage_config = Policyfile::StorageConfig.new.use_policyfile(policyfile_full_path)
 
         @policyfile_content = nil
@@ -51,9 +51,11 @@ module ChefCLI
       end
 
       def run(cookbooks_to_update = [], exclude_deps = false)
-        unless File.exist?(policyfile_expanded_path)
-          # TODO: suggest next step. Add a generator/init command? Specify path to Policyfile.rb?
-          # See card CC-232
+        # TODO: suggest next step. Add a generator/init command? Specify path to Policyfile.rb?
+        # See card CC-232
+        if @policyfile_rel_path.end_with?(".lock.json") && !File.exist?(policyfile_lock_expanded_path)
+          raise PolicyfileNotFound, "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
+        elsif @policyfile_rel_path.end_with?(".rb") && !File.exist?(policyfile_expanded_path)
           raise PolicyfileNotFound, "Policyfile not found at path #{policyfile_expanded_path}"
         end
 

--- a/spec/unit/policyfile/storage_config_spec.rb
+++ b/spec/unit/policyfile/storage_config_spec.rb
@@ -106,10 +106,10 @@ describe ChefCLI::Policyfile::StorageConfig do
 
     end
 
-    context "when the policyfile file name doesn't have a .rb extension" do
+    context "when the policyfile file name doesn't have an .rb or .lock.json extension" do
 
       it "raises an error" do
-        err_string = %q{Policyfile filenames must end with `.rb' extension (you gave: `Policyfile')}
+        err_string = %q{Policyfile filenames must end with an `.rb' or `.lock.json' extension (you gave: `Policyfile')}
         expect { storage_config.use_policyfile("Policyfile") }.to raise_error(ChefCLI::InvalidPolicyfileFilename, err_string)
       end
 

--- a/spec/unit/policyfile_services/install_spec.rb
+++ b/spec/unit/policyfile_services/install_spec.rb
@@ -77,6 +77,16 @@ describe ChefCLI::PolicyfileServices::Install do
 
   end
 
+  context "When an explicit Policfyfile lock name is given and does not exist" do
+
+    let(:policyfile_rb_explicit_name) { "i_do_not_exist.lock.json" }
+
+    it "errors out" do
+      expect { install_service.run }.to raise_error(ChefCLI::PolicyfileNotFound, "Policyfile lock not found at path #{policyfile_rb_path}")
+    end
+
+  end
+
   context "When an explicit Policfyfile name is given and does not exist" do
 
     let(:policyfile_rb_explicit_name) { "i_do_not_exist.rb" }

--- a/spec/unit/policyfile_services/install_spec.rb
+++ b/spec/unit/policyfile_services/install_spec.rb
@@ -77,6 +77,16 @@ describe ChefCLI::PolicyfileServices::Install do
 
   end
 
+  context "When an explicit Policfyfile name is given and does not exist" do
+
+    let(:policyfile_rb_explicit_name) { "i_do_not_exist.rb" }
+
+    it "errors out" do
+      expect { install_service.run }.to raise_error(ChefCLI::PolicyfileNotFound, "Policyfile not found at path #{policyfile_rb_path}")
+    end
+
+  end
+
   context "when a Policyfile exists" do
 
     before do


### PR DESCRIPTION
## Description
The install.rb script in the Chef CLI tool checked for the present of a policy file ending with
an .rb extension even when a lockfile (.lock.json) was passed as an argument. This produced
an error when a user tried to install from a .lock.json file.

### Changes:

- Modified code in install.rb to check extension in the file path, and then verify that a policy file exists 
with that extension.
- Modified code in storage_config_spec.rb so that error messaging now includes .lock.json as an
extension. 
- Added test to verify new error language, and added a test to check for failure when a policy file
is passed as an argument, but doesn't exist.


## Types of changes:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
