### PR TITLE
Convert to autoload and resolve YAML failures with Chef 16.5

### DIFF
--- a/lib/chef-cli/command/env.rb
+++ b/lib/chef-cli/command/env.rb
@@ -20,8 +20,11 @@ require_relative "../cookbook_omnifetch"
 require_relative "../ui"
 require_relative "../version"
 require_relative "../dist"
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
-require "yaml" unless defined?(YAML)
+
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
+autoload :YAML, "yaml"
 
 module ChefCLI
   module Command
@@ -40,7 +43,7 @@ module ChefCLI
         info[ChefCLI::Dist::PRODUCT] = workstation_info
         info["Ruby"] = ruby_info
         info["Path"] = paths
-        ui.msg info.to_yaml
+        ui.msg YAML.dump(info)
       end
 
       def workstation_info

--- a/lib/chef-cli/command/exec.rb
+++ b/lib/chef-cli/command/exec.rb
@@ -17,7 +17,10 @@
 
 require_relative "base"
 require_relative "../dist"
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
 
 module ChefCLI
   module Command

--- a/lib/chef-cli/command/generator_commands.rb
+++ b/lib/chef-cli/command/generator_commands.rb
@@ -16,7 +16,7 @@
 #
 
 require "mixlib/cli" unless defined?(Mixlib::CLI)
-require "pathname" unless defined?(Pathname)
+autoload :Pathname, "pathname"
 require_relative "base"
 require_relative "../chef_runner"
 require_relative "../generator"

--- a/lib/chef-cli/command/shell_init.rb
+++ b/lib/chef-cli/command/shell_init.rb
@@ -15,13 +15,16 @@
 # limitations under the License.
 #
 
-require "erb" unless defined?(ERB)
+autoload :ERB, "erb"
 
 require_relative "../commands_map"
 require_relative "../builtin_commands"
 require_relative "base"
 require_relative "../dist"
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
 
 module ChefCLI
 

--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
+
 require_relative "exceptions"
 
 module ChefCLI

--- a/lib/chef-cli/policyfile/chef_server_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/chef_server_cookbook_source.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl" unless defined?(FFI_Yajl)
+autoload :FFI_Yajl, "ffi_yajl"
 require_relative "../exceptions"
 require_relative "source_uri"
 require_relative "../chef_server_api_multi"

--- a/lib/chef-cli/policyfile/comparison_base.rb
+++ b/lib/chef-cli/policyfile/comparison_base.rb
@@ -15,8 +15,11 @@
 # limitations under the License.
 #
 
-require "ffi_yajl" unless defined?(FFI_Yajl)
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
+
+autoload :FFI_Yajl, "ffi_yajl"
 require_relative "../service_exceptions"
 
 module ChefCLI

--- a/lib/chef-cli/policyfile/differ.rb
+++ b/lib/chef-cli/policyfile/differ.rb
@@ -18,7 +18,7 @@
 require "diff/lcs"
 require "diff/lcs/hunk"
 require "pastel"
-require "ffi_yajl" unless defined?(FFI_Yajl)
+autoload :FFI_Yajl, "ffi_yajl"
 
 module ChefCLI
   module Policyfile

--- a/lib/chef-cli/policyfile/git_lock_fetcher.rb
+++ b/lib/chef-cli/policyfile/git_lock_fetcher.rb
@@ -15,10 +15,13 @@
 # limitations under the License.
 #
 
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
+
 require_relative "../policyfile_lock"
 require_relative "../exceptions"
 require_relative "../helpers"
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require "tmpdir" unless defined?(Dir.mktmpdir)
 
 module ChefCLI

--- a/lib/chef-cli/policyfile/lister.rb
+++ b/lib/chef-cli/policyfile/lister.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "set" unless defined?(Set)
+autoload :Set, "set"
 
 require "chef/server_api"
 require_relative "../service_exceptions"

--- a/lib/chef-cli/policyfile/solution_dependencies.rb
+++ b/lib/chef-cli/policyfile/solution_dependencies.rb
@@ -16,7 +16,7 @@
 #
 
 require "semverse"
-require "set" unless defined?(Set)
+autoload :Set, "set"
 require_relative "../exceptions"
 
 module ChefCLI

--- a/lib/chef-cli/policyfile/source_uri.rb
+++ b/lib/chef-cli/policyfile/source_uri.rb
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
-require "addressable/uri" unless defined?(Addressable::URI)
+module Addressable
+  autoload :URI, "addressable/uri"
+end
+
 require_relative "../exceptions"
 
 module ChefCLI

--- a/lib/chef-cli/policyfile/undo_stack.rb
+++ b/lib/chef-cli/policyfile/undo_stack.rb
@@ -17,7 +17,7 @@
 
 require "fileutils" unless defined?(FileUtils)
 
-require "ffi_yajl" unless defined?(FFI_Yajl)
+autoload :FFI_Yajl, "ffi_yajl"
 
 require_relative "../helpers"
 require_relative "undo_record"

--- a/lib/chef-cli/policyfile_compiler.rb
+++ b/lib/chef-cli/policyfile_compiler.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "set" unless defined?(Set)
+autoload :Set, "set"
 require "forwardable" unless defined?(Forwardable)
 
 require "solve"

--- a/lib/chef-cli/policyfile_services/clean_policy_cookbooks.rb
+++ b/lib/chef-cli/policyfile_services/clean_policy_cookbooks.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "set" unless defined?(Set)
+autoload :Set, "set"
 
 require "chef/server_api"
 require_relative "../service_exceptions"

--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl" unless defined?(FFI_Yajl)
+autoload :FFI_Yajl, "ffi_yajl"
 
 require_relative "../helpers"
 require_relative "../service_exceptions"

--- a/lib/chef-cli/policyfile_services/push.rb
+++ b/lib/chef-cli/policyfile_services/push.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl" unless defined?(FFI_Yajl)
+autoload :FFI_Yajl, "ffi_yajl"
 
 require_relative "../service_exceptions"
 require "chef/server_api"

--- a/lib/chef-cli/service_exception_inspectors/http.rb
+++ b/lib/chef-cli/service_exception_inspectors/http.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl" unless defined?(FFI_Yajl)
+autoload :FFI_Yajl, "ffi_yajl"
 
 module ChefCLI
   module ServiceExceptionInspectors

--- a/lib/chef-cli/shell_out.rb
+++ b/lib/chef-cli/shell_out.rb
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+module Mixlib
+  autoload :ShellOut, "mixlib/shellout"
+end
 
 module ChefCLI
 

--- a/lib/kitchen/provisioner/chef_zero_capture.rb
+++ b/lib/kitchen/provisioner/chef_zero_capture.rb
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "json" unless defined?(JSON)
 require "kitchen"
 require "kitchen/provisioner/base"
 require "kitchen/provisioner/chef_zero"

--- a/spec/unit/command/env_spec.rb
+++ b/spec/unit/command/env_spec.rb
@@ -16,7 +16,7 @@
 #
 
 require "spec_helper"
-require "yaml" unless defined?(YAML)
+autoload :YAML, "yaml"
 require "chef-cli/command/env"
 
 describe ChefCLI::Command::Env do


### PR DESCRIPTION
Our use of .to_yaml is breaking with Chef Infra Client 16.5 and later. I
also pulled in many of the same autoloads we're using in chef itself to
improve performance.

Signed-off-by: Tim Smith <tsmith@chef.io>