### PR TITLE
Create a .vscode dir in cookbooks if vscode is installed

### DIFF
--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -137,6 +137,7 @@ module ChefCLI
           Generator.add_attr_to_context(:use_policyfile, policy_mode?)
           Generator.add_attr_to_context(:pipeline, pipeline)
           Generator.add_attr_to_context(:kitchen, kitchen)
+          Generator.add_attr_to_context(:vscode_dir, create_vscode_dir?)
         end
 
         def kitchen
@@ -234,6 +235,10 @@ module ChefCLI
             return true if File.directory?(File.join(dir.to_s, ".git"))
           end
           false
+        end
+
+        def create_vscode_dir?
+          ::File.exist?("/Applications/Visual Studio Code.app") || ::File.exist?("#{ENV["APPDATA"]}\\Code")
         end
       end
     end

--- a/lib/chef-cli/skeletons/code_generator/files/default/gitignore
+++ b/lib/chef-cli/skeletons/code_generator/files/default/gitignore
@@ -16,7 +16,7 @@ bin/*
 .kitchen/
 kitchen.local.yml
 
-# Chef
+# Chef Infra
 Berksfile.lock
 .zero-knife.rb
 Policyfile.lock.json

--- a/lib/chef-cli/skeletons/code_generator/files/default/repo/README.md
+++ b/lib/chef-cli/skeletons/code_generator/files/default/repo/README.md
@@ -2,7 +2,7 @@
 
 Every Chef Infra installation needs a Chef Repository. This is the place where cookbooks, policyfiles, config files and other artifacts for managing systems with Chef Infra will live. We strongly recommend storing this repository in a version control system such as Git and treating it like source code.
 
-# Repository Directories
+## Repository Directories
 
 This repository contains several directories, and each directory contains a README file that describes what it is for in greater detail, and how to use it for managing your systems with Chef.
 
@@ -11,10 +11,10 @@ This repository contains several directories, and each directory contains a READ
 - `roles/` - Store roles in .rb or .json in the repository.
 - `environments/` - Store environments in .rb or .json in the repository.
 
-# Configuration
+## Configuration
 
 The config file, `.chef/config.rb` is a repository-specific configuration file for the knife command line tool. If you're using the Hosted Chef platform, you can download one for your organization from the management console. You can also generate a new config.rb by running `knife configure`. For more information about configuring Knife, see the Knife documentation at https://docs.chef.io/workstation/knife/
 
-# Next Steps
+## Next Steps
 
 Read the README file in each of the subdirectories for more information about what goes in those directories.

--- a/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
@@ -91,7 +91,7 @@ template "#{cookbook_dir}/test/integration/default/default_test.rb" do
   action :create_if_missing
 end
 
-# Chefspec
+# ChefSpec
 directory "#{cookbook_dir}/spec/unit/recipes" do
   recursive true
 end
@@ -113,7 +113,6 @@ template "#{cookbook_dir}/spec/unit/recipes/default_spec.rb" do
 end
 
 # Recipes
-
 directory "#{cookbook_dir}/recipes"
 
 template "#{cookbook_dir}/recipes/default.rb" do
@@ -161,6 +160,20 @@ if context.have_git
       command('git commit -m "Add generated cookbook content"')
       cwd cookbook_dir
     end
+  end
+end
+
+if context.vscode_dir
+  directory "#{cookbook_dir}/.vscode"
+
+  file "#{cookbook_dir}/.vscode/extensions.json" do
+    content <<~CONTENT
+    {
+      "recommendations": [
+          "chef-software.chef"
+      ]
+    }
+    CONTENT
   end
 end
 


### PR DESCRIPTION
This allows us to get our plugin installed, which is incredibly helpful to cookbook authors using vscode. We know from previous surveys that over 80% of our customers are using vscode, but just in case we'll skip it.

Signed-off-by: Tim Smith <tsmith@chef.io>