### PR TITLE
Permit missing chef_config in ArtifactoryCookbookSource

### DIFF
--- a/lib/chef-cli/policyfile/artifactory_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/artifactory_cookbook_source.rb
@@ -82,10 +82,14 @@ module ChefCLI
         "artifactory(#{uri})"
       end
 
+      def artifactory_api_key
+        chef_config&.artifactory_api_key || ENV["ARTIFACTORY_API_KEY"]
+      end
+
       private
 
       def http_connection_for(base_url)
-        headers = { "X-Jfrog-Art-API" => chef_config.artifactory_api_key || ENV["ARTIFACTORY_API_KEY"] }
+        headers = { "X-Jfrog-Art-API" => artifactory_api_key }
         @http_connections[base_url] ||= Chef::HTTP::Simple.new(base_url, headers: headers)
       end
 


### PR DESCRIPTION
When `policyfile/artifactory_cookbook_source` is included in tests,
it hooks rspec suite execution to initialize/install the policyfile
before  execution the tests.

In test cases, this means a valid `chef_config` is not present because
the hook does not provid a valid `chef_config`.

This change ensures that even when chef-config is absent, we fall back
correctly to the environment variable `ARTIFACTORY_API_KEY`

Fixes #138

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
]