### PR TITLE
Removed reference to http monkeypatch

### DIFF
--- a/spec/unit/service_exception_inspectors/http_spec.rb
+++ b/spec/unit/service_exception_inspectors/http_spec.rb
@@ -17,7 +17,6 @@
 
 require "spec_helper"
 require "net/http" unless defined?(Net::HTTP)
-require "chef/monkey_patches/net_http"
 require "chef-cli/service_exception_inspectors/http"
 
 describe ChefCLI::ServiceExceptionInspectors::HTTP do


### PR DESCRIPTION
This was removed from chef when b58460543a03e5e317637315b647d7ed74f0380f
was merged into chef via https://github.com/chef/chef/pull/10548

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
