### PR TITLE
Remove references to patched version of net/http

### DIFF
--- a/lib/chef-cli/policyfile/comparison_base.rb
+++ b/lib/chef-cli/policyfile/comparison_base.rb
@@ -21,6 +21,7 @@ end
 
 autoload :FFI_Yajl, "ffi_yajl"
 require_relative "../service_exceptions"
+require "net/protocol" unless defined?(Net::ProtocolError)
 
 module ChefCLI
   module Policyfile

--- a/lib/chef-cli/policyfile/remote_lock_fetcher.rb
+++ b/lib/chef-cli/policyfile/remote_lock_fetcher.rb
@@ -18,7 +18,7 @@
 require_relative "../policyfile_lock"
 require_relative "lock_fetcher_mixin"
 require_relative "../exceptions"
-require "chef/http"
+require "net/protocol" unless defined?(Net::ProtocolError)
 require "tempfile" unless defined?(Tempfile)
 
 module ChefCLI

--- a/lib/chef-cli/service_exception_inspectors/http.rb
+++ b/lib/chef-cli/service_exception_inspectors/http.rb
@@ -33,17 +33,11 @@ module ChefCLI
 
       def extended_error_info
         <<~END
-          --- REQUEST DATA ----
-          #{http_method} #{uri}
-          #{request_headers}
-          #{req_body}
-
           --- RESPONSE DATA ---
           #{code} #{response_message}
           #{response_headers}
 
           #{response_body}
-
         END
       end
 
@@ -90,28 +84,8 @@ module ChefCLI
         headers_s
       end
 
-      def request
-        exception.chef_rest_request
-      end
-
       def uri
         request.uri.to_s + request.path.to_s
-      end
-
-      def http_method
-        request.method
-      end
-
-      def request_headers
-        headers_s = ""
-        request.each_header do |key, value|
-          headers_s << key << ": " << value << "\n"
-        end
-        headers_s
-      end
-
-      def req_body
-        request.body
       end
 
     end

--- a/spec/unit/service_exception_inspectors/http_spec.rb
+++ b/spec/unit/service_exception_inspectors/http_spec.rb
@@ -16,7 +16,7 @@
 #
 
 require "spec_helper"
-require "net/http" unless defined?(Net::HTTP)
+require "net/http"
 require "chef-cli/service_exception_inspectors/http"
 
 describe ChefCLI::ServiceExceptionInspectors::HTTP do
@@ -63,7 +63,7 @@ describe ChefCLI::ServiceExceptionInspectors::HTTP do
   end
 
   let(:exception) do
-    Net::HTTPClientException.new(message, response).tap { |e| e.chef_rest_request = request }
+    Net::HTTPClientException.new(message, response)
   end
 
   subject(:inspector) { described_class.new(exception) }
@@ -102,22 +102,9 @@ describe ChefCLI::ServiceExceptionInspectors::HTTP do
 
   end
 
-  describe "showing the request and response in extended error info" do
+  describe "showing the response in extended error info" do
 
     let(:response_body) { "this is the response" }
-
-    it "shows the request in a format similar to HTTP messages" do
-      expected_request_string = <<~E
-        --- REQUEST DATA ----
-        POST /organizations/chef-oss-dev/cookbooks
-        content-type: application/json
-        accept: application/json
-
-        this is the request
-
-      E
-      expect(inspector.extended_error_info).to include(expected_request_string)
-    end
 
     it "shows the response in a format similar to HTTP messages" do
       expected_response_string = <<~E


### PR DESCRIPTION
This follows up on the previous commit which was merged a little too
soon.

The net/http monkeypatch was removed from chef when
b58460543a03e5e317637315b647d7ed74f0380f was merged
via https://github.com/chef/chef/pull/10548

This means request data is no longer available in Net::HTTPException.
There's no option to get it back short of a new monkeypatch
to inject at origin, which is what we just removed in chef 16.

This change change removes our usage of it in chef-cli.
Exception inspector will no longer
no longer provide request data in its output for net/http exceptions.

Also patched up a couple of places where we referred to Net::
constants without requiring them first.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
