### PR TITLE
Allow cookbook files to be generated into subdirectories. 

### DIFF
--- a/lib/chef-cli/skeletons/code_generator/files/default/gitignore
+++ b/lib/chef-cli/skeletons/code_generator/files/default/gitignore
@@ -20,3 +20,6 @@ kitchen.local.yml
 Berksfile.lock
 .zero-knife.rb
 Policyfile.lock.json
+
+.idea/
+

--- a/lib/chef-cli/skeletons/code_generator/recipes/cookbook_file.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/cookbook_file.rb
@@ -1,7 +1,10 @@
 context = ChefCLI::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
-files_dir = File.join(cookbook_dir, 'files')
-cookbook_file_path = File.join(files_dir, context.new_file_basename)
+new_file_basename = File.basename(context.new_file_basename)
+relative_path = File.dirname(context.new_file_basename)
+relative_path.slice! "."
+files_dir = File.join(cookbook_dir, 'files', relative_path)
+cookbook_file_path = File.join(files_dir, new_file_basename)
 
 directory files_dir do
   recursive true
@@ -19,5 +22,4 @@ else
     source 'cookbook_file.erb'
     helpers(ChefCLI::Generator::TemplateHelper)
   end
-
 end

--- a/spec/unit/command/generator_commands/cookbook_file_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_file_spec.rb
@@ -28,4 +28,13 @@ describe ChefCLI::Command::GeneratorCommands::CookbookFile do
     let(:new_file_name) { "new_file.txt" }
 
   end
+
+  include_examples "a file generator" do
+
+    let(:generator_name) { "file" }
+    let(:generated_files) { [ "files/file/new_file.txt" ] }
+    let(:new_file_name) { "file/new_file.txt" }
+
+  end
+
 end


### PR DESCRIPTION
This corrects an issue where an error occurs if someone tries to generate a cookbook file in a nested directory. 

As an example, `chef generate file cookbooks/email_handler/handlers email_handler.rb` now creates a hierarchy:

```
cookbooks/email_handler
├── files
│       └── handlers
│           └── email_handler.rb
```

Previously it would fail with `Error executing action `create` on resource 'template[cookbooks/email_handler/files/default/handlers/email_handler.rb]'`

## Related Issue
Fixes #91 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).