### PR TITLE
update should do install when no .lock file present

### DIFF
--- a/lib/chef-cli/command/update.rb
+++ b/lib/chef-cli/command/update.rb
@@ -91,7 +91,7 @@ module ChefCLI
       def run(params = [])
         return 1 unless apply_params!(params)
 
-        attributes_updater.run if update_attributes_only?
+        attributes_updater.run if update_attributes_only? #should run when --attribute flag is true.
         installer.run(@cookbooks_to_update, config[:exclude_deps]) unless update_attributes_only?
         0
       rescue PolicyfileServiceError => e

--- a/lib/chef-cli/command/update.rb
+++ b/lib/chef-cli/command/update.rb
@@ -91,7 +91,7 @@ module ChefCLI
       def run(params = [])
         return 1 unless apply_params!(params)
 
-        attributes_updater.run
+        attributes_updater.run if update_attributes_only?
         installer.run(@cookbooks_to_update, config[:exclude_deps]) unless update_attributes_only?
         0
       rescue PolicyfileServiceError => e

--- a/lib/chef-cli/command/update.rb
+++ b/lib/chef-cli/command/update.rb
@@ -91,7 +91,7 @@ module ChefCLI
       def run(params = [])
         return 1 unless apply_params!(params)
 
-        attributes_updater.run if update_attributes_only? #should run when --attribute flag is true.
+        attributes_updater.run if update_attributes_only?
         installer.run(@cookbooks_to_update, config[:exclude_deps]) unless update_attributes_only?
         0
       rescue PolicyfileServiceError => e

--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -61,7 +61,7 @@ module ChefCLI
 
         if installing_from_lock?
           install_from_lock
-        elsif cookbooks_to_update.empty? # means update everything
+        elsif cookbooks_to_update.empty? || policyfile_lock.nil? # means update everything
           generate_lock_and_install
         else
           update_lock_and_install(cookbooks_to_update, exclude_deps)

--- a/spec/unit/command/update_spec.rb
+++ b/spec/unit/command/update_spec.rb
@@ -132,10 +132,6 @@ describe ChefCLI::Command::Update do
     context "when the command is successful" do
       before do
         expect(install_service).to receive(:run)
-        expect(ChefCLI::PolicyfileServices::UpdateAttributes).to receive(:new)
-          .with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, chef_config: anything)
-          .and_return(update_attrs_service)
-        expect(update_attrs_service).to receive(:run)
       end
 
       it "returns 0" do
@@ -159,10 +155,6 @@ describe ChefCLI::Command::Update do
 
       before do
         expect(install_service).to receive(:run).and_raise(exception)
-        expect(ChefCLI::PolicyfileServices::UpdateAttributes).to receive(:new)
-          .with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, chef_config: anything)
-          .and_return(update_attrs_service)
-        expect(update_attrs_service).to receive(:run)
       end
 
       it "returns 1" do

--- a/spec/unit/policyfile_services/install_spec.rb
+++ b/spec/unit/policyfile_services/install_spec.rb
@@ -54,6 +54,10 @@ describe ChefCLI::PolicyfileServices::Install do
 
   let(:overwrite) { false }
 
+  let(:cookbooks_to_update) { [] || [ "my_cookbook" ] }
+
+  let(:cookbooks_to_update_empty) { false }
+
   let(:ui) { TestHelpers::TestUI.new }
 
   let(:install_service) { described_class.new(policyfile: policyfile_rb_name, ui: ui, root_dir: working_dir, overwrite: overwrite) }
@@ -149,6 +153,90 @@ describe ChefCLI::PolicyfileServices::Install do
       it "prints the lockfile's revision id" do
         install_service.run
         expect(ui.output).to include("Policy revision id: 7da81d2c7bb97f904637f97e7f8b487fa4bb1ed682edea7087743dec84c254ec")
+      end
+
+    end
+
+    context "when cookbook to update is empty and no policy lock exist" do
+
+      let(:cookbooks_to_update_empty) { true }
+
+      it "create the policy lock" do
+        install_service.run(:cookbooks_to_update)
+        generated_lock = result_policyfile_lock
+        expect(generated_lock.name).to eq("install-example")
+        expect(generated_lock.cookbook_locks).to have_key("local-cookbook")
+      end
+
+      it "checks for policy lock" do
+        lock = install_service.policyfile_lock
+        expect(lock).to eq(nil)
+      end
+
+    end
+
+    context "when cookbook to update is empty and policy lock exist" do
+
+      before do
+        install_service.dup.run
+      end
+
+      let(:cookbooks_to_update_empty) { true }
+
+      it "create the policy lock" do
+        install_service.run(:cookbooks_to_update)
+        generated_lock = result_policyfile_lock
+        expect(generated_lock.name).to eq("install-example")
+        expect(generated_lock.cookbook_locks).to have_key("local-cookbook")
+      end
+
+      it "checks for policy lock" do
+        lock = install_service.policyfile_lock
+        expect(lock).to be_an_instance_of(ChefCLI::PolicyfileLock)
+        expect(lock.name).to eq("install-example")
+        expect(lock.cookbook_locks).to have_key("local-cookbook")
+      end
+
+    end
+
+    context "when cookbook to update is not empty and no policy lock exist" do
+
+      let(:cookbooks_to_update) { [ "my_cookbook" ] }
+
+      it "create the policy lock" do
+        install_service.run(:cookbooks_to_update)
+        generated_lock = result_policyfile_lock
+        expect(generated_lock.name).to eq("install-example")
+        expect(generated_lock.cookbook_locks).to have_key("local-cookbook")
+      end
+
+      it "checks for policy lock" do
+        lock = install_service.policyfile_lock
+        expect(lock).to eq(nil)
+      end
+
+    end
+
+    context "when cookbook to update is not empty and policy lock exist" do
+
+      before do
+        install_service.dup.run
+      end
+
+      let(:cookbooks_to_update) { [ "my_cookbook" ] }
+
+      it "create the policy lock" do
+        install_service.run(:cookbooks_to_update)
+        generated_lock = result_policyfile_lock
+        expect(generated_lock.name).to eq("install-example")
+        expect(generated_lock.cookbook_locks).to have_key("local-cookbook")
+      end
+
+      it "create the policy lock" do
+        lock = install_service.policyfile_lock
+        expect(lock).to be_an_instance_of(ChefCLI::PolicyfileLock)
+        expect(lock.name).to eq("install-example")
+        expect(lock.cookbook_locks).to have_key("local-cookbook")
       end
 
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Error in chef update if lockfile doesn't exist.

If the operator has provided the ```--attributes``` flag with the update command itself than it should only attempt to perform the attributes update instead of doing it with every invocation of the update command.

Running with --attributes flag will require a lockfile, and will not generate a lockfile

Running update without ```--attributes``` flag:

1. lockfile does not exist: generate new lockfile.
2. lockfile exists and cookbooks are provided: update the named cookbooks in lockfile.
3. lockfile exists and cookbooks are not provided: update all deps in the lockfile

## Related Issue
fixes #81 
