### PR TITLE
Allow generator directory to be renamed after generation without breaking usage

### DIFF
--- a/lib/chef-cli/command/generator_commands/generator_generator.rb
+++ b/lib/chef-cli/command/generator_commands/generator_generator.rb
@@ -109,7 +109,7 @@ module ChefCLI
         # @api private
         def metadata_rb
           <<~METADATA
-            name             '#{cookbook_name}'
+            name             File.basename(File.dirname(__FILE__))
             description      'Custom code generator cookbook for use with #{ChefCLI::Dist::PRODUCT}'
             version          '0.1.0'
 

--- a/spec/unit/command/generator_commands/generator_generator_spec.rb
+++ b/spec/unit/command/generator_commands/generator_generator_spec.rb
@@ -181,7 +181,7 @@ describe ChefCLI::Command::GeneratorCommands::GeneratorGenerator do
         metadata_path = File.join(target_dir, "metadata.rb")
         metadata_content = IO.read(metadata_path)
         expected_metadata = <<~METADATA
-          name             'my_cool_generator'
+          name             File.basename(File.dirname(__FILE__))
           description      'Custom code generator cookbook for use with #{ChefCLI::Dist::PRODUCT}'
           version          '0.1.0'
 


### PR DESCRIPTION
After renaming chef code_generator(default folder from chef generate generator), running chef generate cookbook with -g was giving an error


## Description
As chef generate assumes the generator cookbook's name as the renamed directory name, but something else assumes that the cookbook name is what's defined in the metadata.rb file, which is not changed as it is not something that is dynamically coming from code after the renaming of the default directory(code_generator) name from the chef generate generator

## Related Issue
Fixes https://github.com/chef/chef-cli/issues/89


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
