### PR TITLE
Don't add the Workstation path if it is already there in chef shell-init 

### DIFF
--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -117,18 +117,11 @@ module ChefCLI
       @omnibus_env ||=
         begin
           user_bin_dir = File.expand_path(File.join(Gem.user_dir, "bin"))
-          original_path = ENV["PATH"].split(File::PATH_SEPARATOR)
-          if original_path.include?(omnibus_bin_dir) && original_path.include?(user_bin_dir) && original_path.include?(omnibus_embedded_bin_dir)
-            path = [ ENV["PATH"] ]  
-          else  
-            path = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV["PATH"] ]
-          end
-          unless original_path.include?(git_bin_dir)
-            path << git_bin_dir if Dir.exist?(git_bin_dir)
-          end  
+          path = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV["PATH"].split(File::PATH_SEPARATOR) ]
+          path << git_bin_dir if Dir.exist?(git_bin_dir)
           path << git_windows_bin_dir if Dir.exist?(git_windows_bin_dir)
           {
-            "PATH" => path.join(File::PATH_SEPARATOR),
+            "PATH" => path.flatten.uniq.join(File::PATH_SEPARATOR),
             "GEM_ROOT" => Gem.default_dir,
             "GEM_HOME" => Gem.user_dir,
             "GEM_PATH" => Gem.path.join(File::PATH_SEPARATOR),
@@ -136,14 +129,14 @@ module ChefCLI
         end
     end
 
-    private
-
     def omnibus_expand_path(*paths)
       dir = File.expand_path(File.join(paths))
       raise OmnibusInstallNotFound.new unless dir && File.directory?(dir)
 
       dir
     end
+
+    private
 
     def expected_omnibus_root
       File.expand_path(File.join(Gem.ruby, "..", "..", ".."))

--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -117,8 +117,15 @@ module ChefCLI
       @omnibus_env ||=
         begin
           user_bin_dir = File.expand_path(File.join(Gem.user_dir, "bin"))
-          path = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV["PATH"] ]
-          path << git_bin_dir if Dir.exist?(git_bin_dir)
+          original_path = ENV["PATH"].split(File::PATH_SEPARATOR)
+          if original_path.include?(omnibus_bin_dir) && original_path.include?(user_bin_dir) && original_path.include?(omnibus_embedded_bin_dir)
+            path = [ ENV["PATH"] ]  
+          else  
+            path = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV["PATH"] ]
+          end
+          unless original_path.include?(git_bin_dir)
+            path << git_bin_dir if Dir.exist?(git_bin_dir)
+          end  
           path << git_windows_bin_dir if Dir.exist?(git_windows_bin_dir)
           {
             "PATH" => path.join(File::PATH_SEPARATOR),

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -1,0 +1,111 @@
+# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-cli/helpers"
+
+describe ChefCLI::Helpers do
+  context "path_check!" do
+
+    before do
+      allow(Gem).to receive(:ruby).and_return(ruby_path)
+    end
+
+    context "when installed via omnibus" do
+      before do
+        allow(ChefCLI::Helpers).to receive(:omnibus_install?).and_return true
+      end
+
+      context "on unix" do
+
+        let(:user_bin_dir) { File.expand_path(File.join(Gem.user_dir, "bin")) }
+        let(:omnibus_embedded_bin_dir) { "/opt/chef-workstation/embedded/bin" }
+        let(:omnibus_bin_dir) { "/opt/chef-workstation/bin" }
+        let(:expected_PATH) { [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV["PATH"].split(File::PATH_SEPARATOR) ] }
+        let(:expected_GEM_ROOT) { Gem.default_dir }
+        let(:expected_GEM_HOME) { Gem.user_dir }
+        let(:expected_GEM_PATH) { Gem.path.join(File::PATH_SEPARATOR) }
+        let(:ruby_path) { "/opt/chef-workstation/embedded/bin/ruby" }
+
+        it "#omnibus_env path" do
+          allow(ChefCLI::Helpers).to receive(:omnibus_bin_dir).and_return("/opt/chef-workstation/bin")
+          allow(ChefCLI::Helpers).to receive(:omnibus_embedded_bin_dir).and_return("/opt/chef-workstation/embedded/bin")
+          allow(ChefCLI::Helpers).to receive(:omnibus_env).and_return(
+            "PATH" => expected_PATH.flatten.uniq.join(File::PATH_SEPARATOR),
+            "GEM_ROOT" => expected_GEM_ROOT,
+            "GEM_HOME" => expected_GEM_HOME,
+            "GEM_PATH" => expected_GEM_PATH
+          )
+        end
+      end
+
+      context "on windows" do
+        let(:ruby_path) { "c:/opscode/chef-workstation/embedded/bin/ruby.exe" }
+        let(:user_bin_dir) { File.expand_path(File.join(Gem.user_dir, "bin")) }
+        let(:omnibus_embedded_bin_dir) { "c:/opscode/chef-workstation/embedded/bin" }
+        let(:omnibus_bin_dir) { "c:/opscode/chef-workstation/bin" }
+        let(:expected_GEM_ROOT) { Gem.default_dir }
+        let(:expected_GEM_HOME) { Gem.user_dir }
+        let(:expected_GEM_PATH) { Gem.path.join(File::PATH_SEPARATOR) }
+        let(:omnibus_root) { "c:/opscode/chef-workstation" }
+        let(:expected_PATH) { [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV["PATH"].split(File::PATH_SEPARATOR) ] }
+
+        before do
+          allow(ChefCLI::Helpers).to receive(:expected_omnibus_root).and_return(ruby_path)
+          allow(ChefCLI::Helpers).to receive(:omnibus_install?).and_return(true)
+          allow(Chef::Platform).to receive(:windows?).and_return(true)
+        end
+
+        it "#omnibus_env path" do
+          allow(ChefCLI::Helpers).to receive(:omnibus_bin_dir).and_return("c:/opscode/chef-workstation/bin")
+          allow(ChefCLI::Helpers).to receive(:omnibus_embedded_bin_dir).and_return("c:/opscode/chef-workstation/embedded/bin")
+          allow(ChefCLI::Helpers).to receive(:omnibus_env).and_return(
+            "PATH" => expected_PATH.flatten.uniq.join(File::PATH_SEPARATOR),
+            "GEM_ROOT" => expected_GEM_ROOT,
+            "GEM_HOME" => expected_GEM_HOME,
+            "GEM_PATH" => expected_GEM_PATH
+          )
+        end
+      end
+    end
+
+    context "when not installed via omnibus" do
+
+      before do
+        allow(ChefCLI::Helpers).to receive(:omnibus_install?).and_return false
+      end
+      let(:ruby_path) { "/Users/bog/.lots_o_rubies/2.1.2/bin/ruby" }
+      let(:expected_root_path) { "/Users/bog/.lots_o_rubies" }
+
+      before do
+        allow(File).to receive(:exist?).with(expected_root_path).and_return(false)
+
+        %i{
+          omnibus_root
+          omnibus_bin_dir
+          omnibus_embedded_bin_dir
+        }.each do |method_name|
+          allow(ChefCLI::Helpers).to receive(method_name).and_raise(ChefCLI::OmnibusInstallNotFound.new)
+        end
+      end
+
+      it "skips the sanity check without error" do
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <nikhilgupta2102@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
While initializing the shell via ```shell-init```, this will continue adding workstation locations to the path. 
Now corrected the ```omnibus_env``` path. This change will check if the path is present in the ```ENV["PATH"]``` it will just ignore and if not present then it will add that.

## Related Issue
Fixes. [https://github.com/chef/chef-cli/issues/93](url)

