### PR TITLE
Generate dokken configs with privileged: true

### DIFF
--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  privileged: true # allows systemd services to start
+  privileged: true  # allows systemd services to start
 
 provisioner:
   name: dokken

--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
@@ -1,6 +1,7 @@
 ---
 driver:
   name: dokken
+  privileged: true # allows systemd services to start
 
 provisioner:
   name: dokken


### PR DESCRIPTION
This is required to get systemd services to start and will result in
people being more successful out of the box.

Signed-off-by: Tim Smith <tsmith@chef.io>