### PR TITLE
Expand the warning message when using --workflow

### DIFF
--- a/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
@@ -183,7 +183,7 @@ if context.vscode_dir
 end
 
 if context.enable_workflow
-  warn "The Workflow flag is deprecated as #{ChefCLI::Dist::WORKFLOW} is now EOL as of December 2020."
+  warn "\n---------WARNING---------\nThe --workflow flag is deprecated as #{ChefCLI::Dist::WORKFLOW} is EOL as of December 2020.\n\nThis flag will be ignored and will be removed in a future release.\n-------------------------\n\n"
   directory "#{cookbook_dir}/.delivery"
 
   template "#{cookbook_dir}/.delivery/project.toml" do


### PR DESCRIPTION
```
---------WARNING---------
The --workflow flag is deprecated as Chef Workflow (Delivery) is EOL as of December 2020.

This flag will be ignored and will be removed in a future release.
-------------------------
```

Signed-off-by: Tim Smith <tsmith@chef.io>