### PR TITLE
add policyfile metadata DSL helper

### DIFF
--- a/lib/chef-cli/cookbook_metadata.rb
+++ b/lib/chef-cli/cookbook_metadata.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef-cli/exceptions.rb
+++ b/lib/chef-cli/exceptions.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,6 +69,18 @@ module ChefCLI
   end
 
   class MissingCookbookLockData < StandardError
+  end
+
+  class PolicyfileMissingCookbookMetadata < StandardError
+    def initialize(cookbook_root)
+      super("Policyfile specified to use cookbook metadata, but neither #{cookbook_root}/metadata.rb or #{cookbook_root}/metadata.json was found.")
+    end
+  end
+
+  class PolicyfileBadCookbookMetadata < StandardError
+    def initialize(cookbook_root, e)
+      super("Cookbook metadata for cookbook at #{cookbook_root} could not be parsed:\n    Original Exception: #{e}")
+    end
   end
 
   class InvalidLockfile < StandardError

--- a/lib/chef-cli/policyfile/dsl.rb
+++ b/lib/chef-cli/policyfile/dsl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2019, Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -136,6 +136,20 @@ module ChefCLI
           included_policies << spec
           @errors += spec.errors
         end
+      end
+
+      def metadata
+        cookbook_root = storage_config.relative_paths_root
+        unless File.exist?(File.join(cookbook_root, "metadata.rb")) || File.exist?(File.join(cookbook_root, "metadata.json"))
+          raise PolicyfileMissingCookbookMetadata.new(cookbook_root)
+        end
+        begin
+          cookbook_name = CookbookMetadata.from_path(cookbook_root).cookbook_name
+        rescue Exception => e
+          raise PolicyfileBadCookbookMetadata.new(cookbook_root, e)
+        end
+        name cookbook_name if name.nil?
+        cookbook(cookbook_name, path: ".")
       end
 
       def default

--- a/lib/chef-cli/policyfile/dsl.rb
+++ b/lib/chef-cli/policyfile/dsl.rb
@@ -143,6 +143,7 @@ module ChefCLI
         unless File.exist?(File.join(cookbook_root, "metadata.rb")) || File.exist?(File.join(cookbook_root, "metadata.json"))
           raise PolicyfileMissingCookbookMetadata.new(cookbook_root)
         end
+
         begin
           cookbook_name = CookbookMetadata.from_path(cookbook_root).cookbook_name
         rescue Exception => e

--- a/spec/unit/cookbook_metadata_spec.rb
+++ b/spec/unit/cookbook_metadata_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,25 @@ describe ChefCLI::CookbookMetadata do
     context "and the cookbook has only a metadata.json" do
 
       let(:cookbook_root) { File.join(fixtures_path, "example_cookbook_metadata_json_only") }
+
+      it "has a name" do
+        expect(cookbook.name).to eq("example_cookbook")
+        expect(cookbook.cookbook_name).to eq("example_cookbook")
+      end
+
+      it "has a version" do
+        expect(cookbook.version).to eq("0.1.0")
+      end
+
+      it "has a map of dependencies" do
+        expect(cookbook.dependencies).to eq({})
+      end
+
+    end
+
+    context "and the cookbook has both a metadata.json and an (invalid) metadata.rb" do
+
+      let(:cookbook_root) { File.join(fixtures_path, "example_cookbook_both_metadata") }
 
       it "has a name" do
         expect(cookbook.name).to eq("example_cookbook")

--- a/spec/unit/fixtures/example_cookbook_both_metadata/.gitignore
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/.gitignore
@@ -1,0 +1,17 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/spec/unit/fixtures/example_cookbook_both_metadata/.kitchen.yml
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+  - name: centos-6.4
+
+suites:
+  - name: default
+    run_list:
+      - recipe[bar::default]
+    attributes:

--- a/spec/unit/fixtures/example_cookbook_both_metadata/Berksfile
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/spec/unit/fixtures/example_cookbook_both_metadata/README.md
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/README.md
@@ -1,0 +1,4 @@
+# bar-cookbook
+
+TODO: Enter the cookbook description here.
+

--- a/spec/unit/fixtures/example_cookbook_both_metadata/chefignore
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/spec/unit/fixtures/example_cookbook_both_metadata/metadata.json
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "example_cookbook",
+  "version": "0.1.0"
+}
+

--- a/spec/unit/fixtures/example_cookbook_both_metadata/metadata.rb
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/metadata.rb
@@ -1,0 +1,9 @@
+# This is vitally important for cookbooks that ship with context-dependent
+# metadata.rb (to do things like auto incrementing semantic versioning) where
+# the metadata.json means the cookbook is 'finalized' and must be authoritative.
+# We need to never try to parse metadata.rb if the metadata.json exists.  It isn't
+# sufficient to simply not use the metadata.rb file, but we must allow the
+# metadata.rb to have an invalid parse due to LoadErrors in the environment where
+# the cookbook is being loaded.
+
+raise "we never want to read the metadata.rb if metadata.json exists"

--- a/spec/unit/fixtures/example_cookbook_both_metadata/recipes/default.rb
+++ b/spec/unit/fixtures/example_cookbook_both_metadata/recipes/default.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: example_cookbook
+# Recipe:: default
+#
+# Copyright (C) 2014 
+#
+# 
+#


### PR DESCRIPTION
sugar to pull the policyfile name from the cookbook metadata.rb along
with adding the cookbook.

```ruby
name "base"
run_list "base::default"
default_source :supermarket
cookbook "base", path: "."
```

can be written:

```ruby
metadata
run_list "base::default"
default_source :supermarket
```

analogous to the Berkshelf `metadata` method or the Gemfile `gemspec` method.

NOTE: this slides in an tangential change to test that when metadata.json is present that we never even parse metadata.rb (which is a core chef requirement -- at a "MUST" level -- for all code which parses metadata files)
