### PR TITLE
Add option to `chef export` to specify the policygroup

### DIFF
--- a/lib/chef-cli/command/export.rb
+++ b/lib/chef-cli/command/export.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,6 +67,11 @@ module ChefCLI
         description: "Enable stacktraces and other debug output",
         default:     false
 
+      option :policy_group,
+        long:        "--policy-group POLICY_GROUP",
+        description: "The policy_group to include in the export (default: 'local')",
+        default:     nil
+
       attr_reader :policyfile_relative_path
       attr_reader :export_dir
 
@@ -120,11 +125,14 @@ module ChefCLI
       end
 
       def export_service
-        @export_service ||= PolicyfileServices::ExportRepo.new(policyfile: policyfile_relative_path,
-                                                               export_dir: export_dir,
-                                                               root_dir: Dir.pwd,
-                                                               archive: archive?,
-                                                               force: config[:force])
+        @export_service ||= PolicyfileServices::ExportRepo.new(
+          policyfile: policyfile_relative_path,
+          export_dir: export_dir,
+          root_dir: Dir.pwd,
+          archive: archive?,
+          force: config[:force],
+          policy_group: config[:policy_group]
+        )
       end
 
       def handle_error(error)

--- a/spec/unit/command/export_spec.rb
+++ b/spec/unit/command/export_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,6 +84,10 @@ describe ChefCLI::Command::Export do
         expect(command.export_service.policyfile_filename).to eq(File.expand_path("Policyfile.rb"))
       end
 
+      it "uses the default policy_group name" do
+        expect(command.export_service.policy_group).to eq("local")
+      end
+
     end
 
     context "when a Policyfile relative path and export path are given" do
@@ -96,6 +100,19 @@ describe ChefCLI::Command::Export do
 
       it "configures the export service with the policyfile relative path" do
         expect(command.export_service.policyfile_filename).to eq(File.expand_path("CustomNamedPolicy.rb"))
+      end
+    end
+
+    context "when a policy_group is given" do
+
+      let(:params) { [ "path/to/export", "--policy_group", "production" ] }
+
+      it "configures the export service with the export path" do
+        expect(command.export_service.export_dir).to eq(File.expand_path("path/to/export"))
+      end
+
+      it "configures the export service with the policyfile relative path" do
+        expect(command.export_service.policy_group).to eq("production")
       end
     end
   end

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -298,10 +298,10 @@ describe ChefCLI::PolicyfileServices::ExportRepo do
                 exit!(1)
               end
 
-                CONFIG
-                config_path = File.join(export_dir, ".chef", "config.rb")
-                expect(File).to exist(config_path)
-                expect(IO.read(config_path)).to eq(expected_config_text)
+            CONFIG
+            config_path = File.join(export_dir, ".chef", "config.rb")
+            expect(File).to exist(config_path)
+            expect(IO.read(config_path)).to eq(expected_config_text)
           end
 
           it "generates a README.md in the exported repo" do
@@ -348,10 +348,10 @@ describe ChefCLI::PolicyfileServices::ExportRepo do
                 exit!(1)
               end
 
-                CONFIG
-                config_path = File.join(export_dir, ".chef", "config.rb")
-                expect(File).to exist(config_path)
-                expect(IO.read(config_path)).to eq(expected_config_text)
+              CONFIG
+              config_path = File.join(export_dir, ".chef", "config.rb")
+              expect(File).to exist(config_path)
+              expect(IO.read(config_path)).to eq(expected_config_text)
             end
           end
 


### PR DESCRIPTION
This will (with some additional patches to test-kitchen) allow test-kitchen users to test policy_groups other
than the current hardcoded 'local'.