### PR TITLE
fix incorrect logic in code_generator for .delivery

### DIFF
--- a/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/cookbook.rb
@@ -132,7 +132,7 @@ else
 end
 
 # the same will be done below if workflow was enabled so avoid double work and skip this
-unless context.enable_workflow
+if context.enable_workflow
   directory "#{cookbook_dir}/.delivery"
 
   template "#{cookbook_dir}/.delivery/project.toml" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
There appears to be incorrect logic keying off of the `enable_workflow` which was throwing errors in our generator wrapper. If the expected behavior is to do things when `enable_workflow` is `true`, then I think the propose change is needed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
None.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

