### PR TITLE
Supporting -c & -d flags for all the chef-cli commands.

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -34,16 +34,7 @@ steps:
     executor:
       docker:
         image: ruby:3.0-buster
-
-- label: run-specs-windows-2.6
-  command:
-    - powershell .expeditor/run_windows_tests.ps1 rspec
-  expeditor:
-    executor:
-      docker:
-        host_os: windows
-        image: rubydistros/windows-2019:2.6
-
+        
 - label: run-specs-windows-2.7
   command:
     - powershell .expeditor/run_windows_tests.ps1 rspec

--- a/lib/chef-cli/command/base.rb
+++ b/lib/chef-cli/command/base.rb
@@ -42,6 +42,17 @@ module ChefCLI
         description: "Show #{ChefCLI::Dist::PRODUCT} version",
         boolean: true
 
+      option :debug,
+        short:       "-D",
+        long:        "--debug",
+        description: "Enable stacktraces and other debug output",
+        default:     false
+
+      option :config_file,
+        short:       "-c CONFIG_FILE",
+        long:        "--config CONFIG_FILE",
+        description: "Path to configuration file"
+
       def initialize
         super
       end

--- a/lib/chef-cli/command/clean_policy_cookbooks.rb
+++ b/lib/chef-cli/command/clean_policy_cookbooks.rb
@@ -43,17 +43,6 @@ module ChefCLI
 
       BANNER
 
-      option :config_file,
-        short:        "-c CONFIG_FILE",
-        long:         "--config CONFIG_FILE",
-        description:  "Path to configuration file"
-
-      option :debug,
-        short:        "-D",
-        long:         "--debug",
-        description:  "Enable stacktraces and other debug output",
-        default:      false
-
       include Configurable
 
       attr_accessor :ui

--- a/lib/chef-cli/command/clean_policy_revisions.rb
+++ b/lib/chef-cli/command/clean_policy_revisions.rb
@@ -42,17 +42,6 @@ module ChefCLI
 
       BANNER
 
-      option :config_file,
-        short:        "-c CONFIG_FILE",
-        long:         "--config CONFIG_FILE",
-        description:  "Path to configuration file"
-
-      option :debug,
-        short:        "-D",
-        long:         "--debug",
-        description:  "Enable stacktraces and other debug output",
-        default:      false
-
       include Configurable
 
       attr_accessor :ui

--- a/lib/chef-cli/command/delete_policy.rb
+++ b/lib/chef-cli/command/delete_policy.rb
@@ -42,17 +42,6 @@ module ChefCLI
 
       BANNER
 
-      option :config_file,
-        short:        "-c CONFIG_FILE",
-        long:         "--config CONFIG_FILE",
-        description:  "Path to configuration file"
-
-      option :debug,
-        short:        "-D",
-        long:         "--debug",
-        description:  "Enable stacktraces and other debug output",
-        default:      false
-
       include Configurable
 
       attr_accessor :ui

--- a/lib/chef-cli/command/delete_policy_group.rb
+++ b/lib/chef-cli/command/delete_policy_group.rb
@@ -42,17 +42,6 @@ module ChefCLI
 
       BANNER
 
-      option :config_file,
-        short:        "-c CONFIG_FILE",
-        long:         "--config CONFIG_FILE",
-        description:  "Path to configuration file"
-
-      option :debug,
-        short:        "-D",
-        long:         "--debug",
-        description:  "Enable stacktraces and other debug output",
-        default:      false
-
       include Configurable
 
       attr_accessor :ui

--- a/lib/chef-cli/command/diff.rb
+++ b/lib/chef-cli/command/diff.rb
@@ -86,17 +86,6 @@ module ChefCLI
         default:     true,
         boolean:     true
 
-      option :config_file,
-        short:       "-c CONFIG_FILE",
-        long:        "--config CONFIG_FILE",
-        description: "Path to configuration file."
-
-      option :debug,
-        short:       "-D",
-        long:        "--debug",
-        description: "Enable stacktraces and other debug output.",
-        default:     false
-
       attr_accessor :ui
 
       attr_reader :old_base

--- a/lib/chef-cli/command/install.rb
+++ b/lib/chef-cli/command/install.rb
@@ -46,17 +46,6 @@ module ChefCLI
 
       E
 
-      option :config_file,
-        short:       "-c CONFIG_FILE",
-        long:        "--config CONFIG_FILE",
-        description: "Path to configuration file"
-
-      option :debug,
-        short:       "-D",
-        long:        "--debug",
-        description: "Enable stacktraces and other debug output",
-        default:     false
-
       attr_reader :policyfile_relative_path
 
       attr_accessor :ui

--- a/lib/chef-cli/command/push.rb
+++ b/lib/chef-cli/command/push.rb
@@ -44,17 +44,6 @@ module ChefCLI
 
       E
 
-      option :config_file,
-        short:       "-c CONFIG_FILE",
-        long:        "--config CONFIG_FILE",
-        description: "Path to configuration file"
-
-      option :debug,
-        short:       "-D",
-        long:        "--debug",
-        description: "Enable stacktraces and other debug output",
-        default:     false
-
       attr_reader :policyfile_relative_path
       attr_reader :policy_group
 

--- a/lib/chef-cli/command/push_archive.rb
+++ b/lib/chef-cli/command/push_archive.rb
@@ -43,17 +43,6 @@ module ChefCLI
         Options:
       E
 
-      option :config_file,
-        short:       "-c CONFIG_FILE",
-        long:        "--config CONFIG_FILE",
-        description: "Path to configuration file"
-
-      option :debug,
-        short:       "-D",
-        long:        "--debug",
-        description: "Enable stacktraces and other debug output",
-        default:     false
-
       attr_accessor :ui
 
       attr_reader :policy_group

--- a/lib/chef-cli/command/show_policy.rb
+++ b/lib/chef-cli/command/show_policy.rb
@@ -58,17 +58,6 @@ module ChefCLI
         default:     true,
         boolean:     true
 
-      option :config_file,
-        short:        "-c CONFIG_FILE",
-        long:         "--config CONFIG_FILE",
-        description:  "Path to configuration file"
-
-      option :debug,
-        short:        "-D",
-        long:         "--debug",
-        description:  "Enable stacktraces and other debug output",
-        default:      false
-
       include Configurable
 
       attr_accessor :ui

--- a/lib/chef-cli/command/undelete.rb
+++ b/lib/chef-cli/command/undelete.rb
@@ -63,17 +63,6 @@ module ChefCLI
         long:         "--id ID",
         description:  "Undo the delete operation with the given ID"
 
-      option :config_file,
-        short:        "-c CONFIG_FILE",
-        long:         "--config CONFIG_FILE",
-        description:  "Path to configuration file"
-
-      option :debug,
-        short:        "-D",
-        long:         "--debug",
-        description:  "Enable stacktraces and other debug output",
-        default:      false
-
       include Configurable
 
       attr_accessor :ui

--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -29,4 +29,3 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/default
-    attributes:

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -95,7 +95,7 @@ describe ChefCLI::Command::Base do
     run_command(["-u"])
     expect(stdout).to eq("thanks for passing me true\n")
   end
-  
+
   describe "when enforce_license is true" do
     let(:enforce_license) { true }
 

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -16,6 +16,7 @@
 #
 
 require "spec_helper"
+require "chef-cli/command/base"
 
 describe ChefCLI::Command::Base do
   class TestCommand < ChefCLI::Command::Base
@@ -94,7 +95,7 @@ describe ChefCLI::Command::Base do
     run_command(["-u"])
     expect(stdout).to eq("thanks for passing me true\n")
   end
-
+  
   describe "when enforce_license is true" do
     let(:enforce_license) { true }
 
@@ -126,6 +127,8 @@ describe ChefCLI::Command::Base do
         use me please
             -a, --arg ARG                    An option with a required argument
                 --chef-license ACCEPTANCE    Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')
+            -c, --config CONFIG_FILE         Path to configuration file
+            -D, --debug                      Enable stacktraces and other debug output
             -h, --help                       Show this message
             -u, --user                       If the user exists
             -v, --version                    Show #{ChefCLI::Dist::PRODUCT} version
@@ -147,6 +150,8 @@ describe ChefCLI::Command::Base do
         use me please
             -a, --arg ARG                    An option with a required argument
                 --chef-license ACCEPTANCE    Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')
+            -c, --config CONFIG_FILE         Path to configuration file
+            -D, --debug                      Enable stacktraces and other debug output
             -h, --help                       Show this message
             -u, --user                       If the user exists
             -v, --version                    Show #{ChefCLI::Dist::PRODUCT} version

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -400,6 +400,7 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
                 verifier:
                   inspec_tests:
                     - test/integration/default
+                attributes:
           KITCHEN_YML
         end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -400,7 +400,6 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
                 verifier:
                   inspec_tests:
                     - test/integration/default
-                attributes:
           KITCHEN_YML
         end
 


### PR DESCRIPTION
Signed-off-by: Ashwin <avarma@msystechnologies.com>

## Description
- Supporting -c & -d flags for all the commands of chef-cli.
- To test the commands hit `bundle exec chef command-name command-need-to-execute parameters`
- For example:- `bundle exec chef exec ls -c`  


## Related Issue
https://github.com/chef/chef-cli/issues/178

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
