### PR TITLE
Use computed lock revision in policy installer output

### DIFF
--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -112,7 +112,7 @@ module ChefCLI
         ui.msg ""
 
         ui.msg "Lockfile written to #{policyfile_lock_expanded_path}"
-        ui.msg "Policy revision id: #{policyfile_lock.revision_id}"
+        ui.msg "Policy revision id: #{lock_data["revision_id"]}"
       rescue => error
         raise PolicyfileInstallError.new("Failed to generate Policyfile.lock", error)
       end


### PR DESCRIPTION
Otherwise the revision ID is computed from the original state.

## Related Issue
#210 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- 🚫I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
