### PR TITLE
Refactor chef install/update/push command for non-CLI use

### DIFF
--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -37,7 +37,7 @@ module ChefCLI
       attr_reader :overwrite
       attr_reader :chef_config
 
-      def initialize(policyfile: nil, ui: nil, root_dir: nil, overwrite: false, config: nil)
+      def initialize(policyfile: nil, ui: nil, root_dir: nil, overwrite: false, config: nil, calling_request: "CLI")
         @ui = ui
         @overwrite = overwrite
         @chef_config = config
@@ -47,6 +47,7 @@ module ChefCLI
         @storage_config = Policyfile::StorageConfig.new.use_policyfile(policyfile_full_path)
 
         @policyfile_content = nil
+        @calling_request = calling_request
         @policyfile_compiler = nil
       end
 
@@ -54,9 +55,9 @@ module ChefCLI
         # TODO: suggest next step. Add a generator/init command? Specify path to Policyfile.rb?
         # See card CC-232
         if @policyfile_rel_path.end_with?(".lock.json") && !File.exist?(policyfile_lock_expanded_path)
-          raise PolicyfileNotFound, "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
+          raise @calling_request == "CLI" ? PolicyfileNotFound : PolicyfileNotFoundAPI , "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
         elsif @policyfile_rel_path.end_with?(".rb") && !File.exist?(policyfile_expanded_path)
-          raise PolicyfileNotFound, "Policyfile not found at path #{policyfile_expanded_path}"
+          raise @calling_request == "CLI" ? PolicyfileNotFound : PolicyfileNotFoundAPI , "Policyfile not found at path #{policyfile_expanded_path}"
         end
 
         if installing_from_lock?
@@ -66,6 +67,7 @@ module ChefCLI
         else
           update_lock_and_install(cookbooks_to_update, exclude_deps)
         end
+        { "status" => 200, "message" => "Success" } if @calling_request != "CLI"
       end
 
       def policyfile_content

--- a/lib/chef-cli/policyfile_services/push.rb
+++ b/lib/chef-cli/policyfile_services/push.rb
@@ -78,7 +78,7 @@ module ChefCLI
         validate_lockfile
         write_updated_lockfile
         upload_policy
-        { "status" => 200, "message" => "Succeed" } if @calling_request != "CLI"
+        { "status" => 200, "message" => "Success" } if @calling_request != "CLI"
       end
 
       def policyfile_lock

--- a/lib/chef-cli/service_exceptions.rb
+++ b/lib/chef-cli/service_exceptions.rb
@@ -70,6 +70,19 @@ module ChefCLI
   class PolicyfileServiceError < StandardError
   end
 
+  class PolicyfileServiceErrorAPI < StandardError
+    def initialize(msg, exception_type = "API exception")
+      @exception_type = exception_type
+      super( { message: msg, status: 422 }.to_json)
+    end
+  end
+
+  class PolicyfileNotFoundAPI < PolicyfileServiceErrorAPI
+  end
+
+  class LockfileNotFoundAPI < PolicyfileServiceErrorAPI
+  end
+
   class PolicyfileNotFound < PolicyfileServiceError
   end
 

--- a/spec/unit/policyfile_services/install_spec.rb
+++ b/spec/unit/policyfile_services/install_spec.rb
@@ -54,6 +54,8 @@ describe ChefCLI::PolicyfileServices::Install do
 
   let(:overwrite) { false }
 
+  let(:calling_request) { "API" }
+
   let(:cookbooks_to_update) { [] || [ "my_cookbook" ] }
 
   let(:cookbooks_to_update_empty) { false }
@@ -61,6 +63,8 @@ describe ChefCLI::PolicyfileServices::Install do
   let(:ui) { TestHelpers::TestUI.new }
 
   let(:install_service) { described_class.new(policyfile: policyfile_rb_name, ui: ui, root_dir: working_dir, overwrite: overwrite) }
+
+  let(:install_service_api) { described_class.new(policyfile: policyfile_rb_name, ui: ui, root_dir: working_dir, overwrite: overwrite, calling_request: calling_request) }
 
   let(:storage_config) do
     ChefCLI::Policyfile::StorageConfig.new( cache_path: nil, relative_paths_root: local_cookbooks_root )
@@ -77,6 +81,14 @@ describe ChefCLI::PolicyfileServices::Install do
 
     it "errors out" do
       expect { install_service.run }.to raise_error(ChefCLI::PolicyfileNotFound, "Policyfile not found at path #{policyfile_rb_path}")
+    end
+
+  end
+
+  context "when no Policyfile is present or specified call by API client" do
+
+    it "errors out" do
+      expect { install_service_api.run }.to raise_error(ChefCLI::PolicyfileNotFoundAPI, { message: "Policyfile not found at path #{policyfile_rb_path}", status: 422 }.to_json)
     end
 
   end
@@ -105,6 +117,10 @@ describe ChefCLI::PolicyfileServices::Install do
 
     before do
       with_file(policyfile_rb_path) { |f| f.print(policyfile_content) }
+    end
+
+    it "reads the policyfile from disk and create lock file, call by API client" do
+      expect(install_service_api.run).to eq({ "status" => 200, "message" => "Success" })
     end
 
     it "infers that the Policyfile.rb is located at $CWD/Policyfile.rb" do

--- a/spec/unit/policyfile_services/push_spec.rb
+++ b/spec/unit/policyfile_services/push_spec.rb
@@ -46,6 +46,8 @@ describe ChefCLI::PolicyfileServices::Push do
 
   let(:policy_document_native_api) { false }
 
+  let(:calling_request) { "API" }
+
   let(:config) do
     double("Chef::Config",
       chef_server_url: "https://localhost:10443",
@@ -57,6 +59,8 @@ describe ChefCLI::PolicyfileServices::Push do
   let(:ui) { TestHelpers::TestUI.new }
 
   let(:push_service) { described_class.new(policyfile: policyfile_rb_name, policy_group: policy_group, ui: ui, config: config, root_dir: working_dir) }
+
+  let(:push_service_api) { described_class.new(policyfile: policyfile_rb_name, policy_group: policy_group, ui: ui, config: config, root_dir: working_dir, calling_request: calling_request) }
 
   it "configures an HTTP client" do
     expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
@@ -108,7 +112,9 @@ describe ChefCLI::PolicyfileServices::Push do
     it "errors out" do
       expect { push_service.run }.to raise_error(ChefCLI::LockfileNotFound)
     end
-
+    it "errors out, call by API client" do
+      expect { push_service_api.run }.to raise_error(ChefCLI::LockfileNotFoundAPI)
+    end
   end
 
   context "when a lockfile is present" do


### PR DESCRIPTION
Signed-off-by: sachin007jain <sachin.jain@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
The relevant method(s) in chef install/update/push command needs to refactored so that it can be consumed by the CLI as well as API. The CLI specific progress updates and logs provided by the method(s) need to be retained in a way that they are not passed on to the API. Support for synchronous API assumed initially.


`chef install Policyfile.rb`

`chef update Policyfile.rb`

`chef push Policyfile.lock.json`

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
