### PR TITLE
Fix chef-export when cookbook path is long in windows

### DIFF
--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -117,9 +117,6 @@ module ChefCLI
       private
 
       def with_staging_dir
-        # p = Process.pid
-        # t = Time.new.utc.strftime("%Y%m%d%H%M%S") # commenting out as we need to tweak long path which cause issue while exporting in windows machine
-        # path = "chefcli-export-#{p}-#{t}"
         require "securerandom" unless defined?(SecureRandom)
         random_string = SecureRandom.hex(2)
         path = "chef-export-#{random_string}"

--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -121,7 +121,6 @@ module ChefCLI
         # t = Time.new.utc.strftime("%Y%m%d%H%M%S") # commenting out as we need to tweak long path which cause issue while exporting in windows machine
         # path = "chefcli-export-#{p}-#{t}"
         require 'securerandom'
-        require 'byebug'
         random_string = SecureRandom.hex(2)
         path = "chef-export-#{random_string}"
         Dir.mktmpdir(path) do |d|

--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -117,9 +117,14 @@ module ChefCLI
       private
 
       def with_staging_dir
-        p = Process.pid
-        t = Time.new.utc.strftime("%Y%m%d%H%M%S")
-        Dir.mktmpdir("chefcli-export-#{p}-#{t}") do |d|
+        # p = Process.pid
+        # t = Time.new.utc.strftime("%Y%m%d%H%M%S") # commenting out as we need to tweak long path which cause issue while exporting in windows machine
+        # path = "chefcli-export-#{p}-#{t}"
+        require 'securerandom'
+        require 'byebug'
+        random_string = SecureRandom.hex(2)
+        path = "chef-export-#{random_string}"
+        Dir.mktmpdir(path) do |d|
           begin
             @staging_dir = d
             yield

--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -120,7 +120,7 @@ module ChefCLI
         # p = Process.pid
         # t = Time.new.utc.strftime("%Y%m%d%H%M%S") # commenting out as we need to tweak long path which cause issue while exporting in windows machine
         # path = "chefcli-export-#{p}-#{t}"
-        require 'securerandom'
+        require "securerandom" unless defined?(SecureRandom)
         random_string = SecureRandom.hex(2)
         path = "chef-export-#{random_string}"
         Dir.mktmpdir(path) do |d|


### PR DESCRIPTION
Signed-off-by: Pranay Singh <i5singh.pranay@gmail.com>


## Description
The length of temporary file is shortened to allow character limit 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
