### PR TITLE
remove deprecated arguments in erb.new

### DIFF
--- a/lib/chef-cli/command/shell_init.rb
+++ b/lib/chef-cli/command/shell_init.rb
@@ -122,7 +122,7 @@ module ChefCLI
         return "" unless (completion_template_basename = completion_template_for(shell))
 
         completion_template_path = expand_completion_template_path(completion_template_basename)
-        erb = ERB.new(File.read(completion_template_path), nil, "-")
+        erb = ERB.new(File.read(completion_template_path), trim_mode: "-")
         context_binding = shell_completion_template_context.get_binding
         erb.result(context_binding)
       end


### PR DESCRIPTION
## Description
removes deprecation warnings when running chef shell-init

## Related Issue
#219 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
