### PR TITLE
Memoize git shell commands

### DIFF
--- a/spec/unit/cookbook_profiler/git_spec.rb
+++ b/spec/unit/cookbook_profiler/git_spec.rb
@@ -25,7 +25,8 @@ describe ChefCLI::CookbookProfiler::Git do
 
   include ChefCLI::Helpers
 
-  let(:git_profiler) do
+  let!(:git_profiler) do
+    ChefCLI::CookbookProfiler::Git.uncache
     ChefCLI::CookbookProfiler::Git.new(cookbook_path)
   end
 

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -50,6 +50,10 @@ describe ChefCLI::PolicyfileLock, "building a lockfile", :skip_on_windows do
     ChefCLI::Policyfile::StorageConfig.new( cache_path: cache_path, relative_paths_root: relative_paths_root )
   end
 
+  let!(:git_memo) do
+    ChefCLI::CookbookProfiler::Git.uncache
+  end
+
   context "when a cached cookbook omits the cache key" do
 
     let(:policyfile_lock) do


### PR DESCRIPTION
## Description

We have a shell script that invokes `chef install` and `chef export` against a setup with ~30 cookbooks. It was annoyingly slow so we dug into why that was the case. We found that these commands call `ChefCLI::CookbookProfiler::Git` in a loop which ends up shelling out the same handful of git commands repeatedly. For example, one run produced the following duplicate git commands (sorted by dupe count):

```
 74   execve("/usr/bin/git", ["git", "rev-parse", "HEAD"], <snip>
 46   execve("/usr/bin/git", ["git", "rev-parse", "HEAD"], <snip>
 41   execve("/usr/bin/git", ["git", "rev-parse", "--abbrev-ref", "HEAD"], <snip>
 39   execve("/usr/bin/git", ["git", "diff-files", "--quiet"], <snip>
 25   execve("/usr/bin/git", ["git", "branch", "-r", "--contains", "<snip>"], <snip>
 23   execve("/usr/lib/git-core/git", ["/usr/lib/git-core/git", "status", "--porcelain=2", "-uno"], <snip>
 23   execve("/usr/bin/git", ["git", "config", "--get", "branch.HEAD.remote"], <snip>
 21   execve("/usr/bin/git", ["git", "diff-files", "--quiet"], <snip>
 19   execve("/usr/bin/git", ["git", "rev-parse", "--abbrev-ref", "HEAD"], <snip>
 17   execve("/usr/bin/git", ["git", "config", "--get", "branch.<snip>.remote"], <snip>
 16   execve("/usr/bin/git", ["git", "config", "--get", "remote.origin.url"], <snip>
 14   execve("/usr/bin/git", ["git", "branch", "-r", "--contains", "<snip>"], <snip>
 14   execve("/usr/bin/git", ["git", "branch", "-r", "--contains", "<snip>"], <snip>
 12   execve("/usr/bin/git", ["git", "config", "--get", "remote.origin.url"], <snip>
 11   execve("/usr/bin/git", ["git", "config", "--get", "branch.<snip>.remote"], <snip>
  9   execve("/usr/bin/git", ["git", "config", "--get", "branch.HEAD.remote"], <snip>
  7   execve("/usr/bin/git", ["git", "branch", "-r", "--contains", "<snip>"], <snip>
  5   execve("/usr/lib/git-core/git", ["/usr/lib/git-core/git", "status", "--porcelain=2", "-uno"], <snip>
```

These all seem to be cacheable at the repo-level. Adding a simple memoization brought down our run from ~45s to ~1s.

~To be safer, we could wrap this is a `git_memo` method to make the memoization behavior more explicit. I thought I'd collect some initial feedback on the general idea first. For example this would break things if each cookbook were its own repo. I'm not sure if it's that an expected / supported use-case.~

I modified the code to memoize at the repo-level, so cookbook-per-repo should continue to work.

## Related Issue

n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
