### PR TITLE
Implementation of the chef license commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,7 @@ group :profile do
   gem "stackprof-webnav"
   gem "memory_profiler"
 end
+
+source "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local/" do
+  gem "chef-licensing"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,3 @@ group :profile do
   gem "stackprof-webnav"
   gem "memory_profiler"
 end
-
-source "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local/" do
-  gem "chef-licensing"
-end

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
+  gem.add_dependency "chef-licensing", "~> 0.4"
 end

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
-  gem.add_dependency "chef-licensing", "~> 0.4"
+  gem.add_dependency "chef-licensing", "~> 0.7"
 end

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
-  gem.add_dependency "chef-licensing", "~> 0.7"
+  gem.add_dependency "chef-licensing", "~> 1.0"
 end

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
-  gem.add_dependency "chef-licensing", "~> 0.4"
+  # gem.add_dependency "chef-licensing", "~> 0.4"
 end

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
-  # gem.add_dependency "chef-licensing", "~> 0.4"
+  gem.add_dependency "chef-licensing", "~> 0.4"
 end

--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -58,5 +58,5 @@ ChefCLI.commands do |c|
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-cli/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
   c.builtin "license", :License, require_path: "chef-cli/command/license",
-            desc: "View the active license or generate the free/trial licenses for the chef workstation"
+            desc: "Create & install a new license on the system or view installed license(s)."
 end

--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "dist"
+require "chef-cli/licensing/base"
 
 ChefCLI.commands do |c|
   c.builtin "exec", :Exec, require_path: "chef-cli/command/exec",
@@ -57,6 +58,8 @@ ChefCLI.commands do |c|
 
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-cli/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
-  c.builtin "license", :License, require_path: "chef-cli/command/license",
-            desc: "Create & install a new license on the system or view installed license(s)."
+  if ChefCLI::Licensing::Base.feature_enabled?
+    c.builtin "license", :License, require_path: "chef-cli/command/license",
+               desc: "Create & install a new license on the system or view installed license(s)."
+  end
 end

--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -16,7 +16,6 @@
 #
 
 require_relative "dist"
-require "chef-cli/licensing/base"
 
 ChefCLI.commands do |c|
   c.builtin "exec", :Exec, require_path: "chef-cli/command/exec",
@@ -58,8 +57,6 @@ ChefCLI.commands do |c|
 
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-cli/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
-  if ChefCLI::Licensing::Base.feature_enabled?
-    c.builtin "license", :License, require_path: "chef-cli/command/license",
-               desc: "Create & install a new license on the system or view installed license(s)."
-  end
+  c.builtin "license", :License, require_path: "chef-cli/command/license",
+            desc: "Create & install a new license on the system or view installed license(s)."
 end

--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -57,4 +57,6 @@ ChefCLI.commands do |c|
 
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-cli/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
+  c.builtin "license", :License, require_path: "chef-cli/command/license",
+            desc: "View the active license or generate the free/trial licenses for the chef workstation"
 end

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -38,9 +38,13 @@ module ChefCLI
       HELP
 
       SUB_COMMANDS = [
-        { name: "list", description: "List the currently active license" },
-        { name: "add", description: "Create a new Free/Trial license or activate the commercial license" },
+        { name: "list", description: "List details of the license(s) installed on the system." },
+        { name: "add", description: "Create & install a Free/ Trial license or install a Commercial license on the system." },
       ]
+
+      option :chef_license_key,
+        long: "--chef-license-key LICENSE",
+        description: "New license key to accept and store in the system"
 
       attr_accessor :ui
 

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -108,7 +108,7 @@ module ChefCLI
       def validate_feature!
         return if ChefCLI::Licensing::Base.feature_enabled?
 
-        ui.err("This feature is not enabled! Run `<command>` to enable this feature and try again.")
+        ui.err("This feature is not enabled! Run `chef license enable true` to enable this feature and try again.")
         exit 0
       end
     end

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -39,7 +39,7 @@ module ChefCLI
 
       SUB_COMMANDS = [
         { name: "list", description: "List the currently active license" },
-        { name: "add", description: "Create a new Free/Trial license or activate the commercial license" }
+        { name: "add", description: "Create a new Free/Trial license or activate the commercial license" },
       ]
 
       attr_accessor :ui
@@ -49,8 +49,8 @@ module ChefCLI
           #{MAIN_COMMAND_HELP}
           Subcommands:
           #{SUB_COMMANDS.map do |c|
-          "  #{c[:name].ljust(7)}#{c[:description]}"
-        end.join("\n") }
+            "  #{c[:name].ljust(7)}#{c[:description]}"
+          end.join("\n") }
 
           Options:
         BANNER

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -28,7 +28,7 @@ module ChefCLI
 
       include Configurable
 
-      MAIN_COMMAND_HELP = <<~HELP
+      MAIN_COMMAND_HELP = <<~HELP.freeze
         Usage: #{ChefCLI::Dist::EXEC} license [SUBCOMMAND]
 
         `#{ChefCLI::Dist::EXEC} license` command will validate the existing license
@@ -39,7 +39,7 @@ module ChefCLI
       SUB_COMMANDS = [
         { name: "list", description: "List details of the license(s) installed on the system." },
         { name: "add", description: "Create & install a Free/ Trial license or install a Commercial license on the system." },
-      ]
+      ].freeze
 
       option :chef_license_key,
         long: "--chef-license-key LICENSE",

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -66,6 +66,7 @@ module ChefCLI
       end
 
       def run(params)
+        validate_feature!
         config_license_debug if debug?
         remaining_args = parse_options(params)
         return 1 unless validate_params!(remaining_args)
@@ -102,6 +103,13 @@ module ChefCLI
 
       def config_license_debug
         ChefLicensing.output = ui
+      end
+
+      def validate_feature!
+        return if ChefCLI::Licensing::Base.feature_enabled?
+
+        ui.err("This feature is not enabled! Run `<command>` to enable this feature and try again.")
+        exit 0
       end
     end
   end

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -18,7 +18,6 @@
 
 require_relative "base"
 require "chef-cli/licensing/base"
-require "byebug"
 require_relative "../configurable"
 
 module ChefCLI

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -66,7 +66,6 @@ module ChefCLI
       end
 
       def run(params)
-        validate_feature!
         config_license_debug if debug?
         remaining_args = parse_options(params)
         return 1 unless validate_params!(remaining_args)
@@ -103,13 +102,6 @@ module ChefCLI
 
       def config_license_debug
         ChefLicensing.output = ui
-      end
-
-      def validate_feature!
-        return if ChefCLI::Licensing::Base.feature_enabled?
-
-        ui.err("This feature is not enabled! Run `chef license enable true` to enable this feature and try again.")
-        exit 0
       end
     end
   end

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Copyright:: Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "base"
+require "chef-cli/licensing/base"
+require "byebug"
+require_relative "../configurable"
+
+module ChefCLI
+  module Command
+
+    # This class will manage the license command in the chef-cli
+    class License < Base
+
+      include Configurable
+
+      MAIN_COMMAND_HELP = <<~HELP
+        Usage: #{ChefCLI::Dist::EXEC} license [SUBCOMMAND]
+
+        `#{ChefCLI::Dist::EXEC} license` command will validate the existing license
+        or will help you interactively generate new free/trial license and activate the
+        commercial license the chef team has sent you through email.
+      HELP
+
+      SUB_COMMANDS = [
+        { name: "list", description: "List the currently active license" },
+        { name: "add", description: "Create a new Free/Trial license or activate the commercial license" }
+      ]
+
+      attr_accessor :ui
+
+      def self.banner
+        <<~BANNER
+          #{MAIN_COMMAND_HELP}
+          Subcommands:
+          #{SUB_COMMANDS.map do |c|
+          "  #{c[:name].ljust(7)}#{c[:description]}"
+        end.join("\n") }
+
+          Options:
+        BANNER
+      end
+
+      def initialize
+        super
+
+        @ui = UI.new
+      end
+
+      def run(params)
+        config_license_debug if debug?
+        remaining_args = parse_options(params)
+        return 1 unless validate_params!(remaining_args)
+
+        if remaining_args.blank?
+          ChefCLI::Licensing::Base.validate
+        else
+          ChefCLI::Licensing::Base.send(remaining_args[0])
+        end
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def validate_params!(args)
+        if args.length > 1
+          ui.err("Too many arguments")
+          return false
+        end
+
+        valid_subcommands = SUB_COMMANDS.collect { |c| c[:name] }
+        args.each do |arg|
+          next if valid_subcommands.include?(arg)
+
+          ui.err("Invalid option: #{arg}")
+          return false
+        end
+
+        true
+      end
+
+      private
+
+      def config_license_debug
+        ChefLicensing.output = ui
+      end
+    end
+  end
+end

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -24,6 +24,9 @@ module ChefCLI
   module Licensing
     class Base
       class << self
+        def feature_enabled?
+          File.exists?(File.join(Dir.home, ".chef/license_feature.json"))
+        end
 
         def validate
           ChefLicensing.fetch_and_persist.each do |license_key|

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -25,7 +25,7 @@ module ChefCLI
     class Base
       class << self
         def feature_enabled?
-          File.exists?(File.join(Dir.home, ".chef/license_feature.json"))
+          File.exists?(File.join(Dir.home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c"))
         end
 
         def validate

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -20,7 +20,6 @@ require "chef-licensing"
 require_relative "config"
 require "faraday_middleware"
 
-
 module ChefCLI
   module Licensing
     class Base

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -28,7 +28,7 @@ module ChefCLI
 
         def validate
           ChefLicensing.fetch_and_persist.each do |license_key|
-            ui.msg "License Key: #{license_key}"
+            puts "License Key: #{license_key}"
           end
         end
 

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright:: Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef-licensing"
+require_relative "config"
+
+module ChefCLI
+  module Licensing
+    class Base
+      class << self
+
+        def validate
+          ChefLicensing.fetch_and_persist.each do |license_key|
+            ui.msg "License Key: #{license_key}"
+          end
+        end
+
+        def list
+          ChefLicensing.list_license_keys_info
+        end
+
+        def add
+          ChefLicensing.add_license
+        end
+      end
+    end
+  end
+end

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -18,6 +18,8 @@
 
 require "chef-licensing"
 require_relative "config"
+require "faraday_middleware"
+
 
 module ChefCLI
   module Licensing

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -18,16 +18,11 @@
 
 require "chef-licensing"
 require_relative "config"
-require "faraday_middleware"
 
 module ChefCLI
   module Licensing
     class Base
       class << self
-        def feature_enabled?
-          File.exists?(File.join(Dir.home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c"))
-        end
-
         def validate
           ChefLicensing.fetch_and_persist.each do |license_key|
             puts "License Key: #{license_key}"

--- a/lib/chef-cli/licensing/config.rb
+++ b/lib/chef-cli/licensing/config.rb
@@ -22,4 +22,6 @@ ChefLicensing.configure do |config|
   config.chef_product_name = "workstation"
   config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
   config.chef_executable_name = "chef"
+  # config.license_server_url = "https://services.chef.io/licensing"
+  config.license_server_url   = "https://licensing-acceptance.chef.co/License"
 end

--- a/lib/chef-cli/licensing/config.rb
+++ b/lib/chef-cli/licensing/config.rb
@@ -19,7 +19,7 @@
 require "chef-licensing"
 
 ChefLicensing.configure do |config|
-  config.chef_product_name = "chef"
-  config.chef_entitlement_id = "a5213d76-181f-4924-adba-4b7ed2b098b5"
+  config.chef_product_name = "workstation"
+  config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
   config.chef_executable_name = "chef"
 end

--- a/lib/chef-cli/licensing/config.rb
+++ b/lib/chef-cli/licensing/config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef-licensing"
+
+ChefLicensing.configure do |config|
+  config.chef_product_name = "chef"
+  config.chef_entitlement_id = "a5213d76-181f-4924-adba-4b7ed2b098b5"
+  config.chef_executable_name = "chef"
+end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -89,6 +89,8 @@ describe ChefCLI::CLI do
 
     commands_map.builtin "example", :TestCommand, require_path: "unit/fixtures/command/cli_test_command",
                                                   desc: "Example subcommand for testing"
+
+    allow(ChefCLI::Licensing::Base).to receive(:validate).and_return(true)
   end
 
   context "given no arguments or options" do

--- a/spec/unit/command/license_spec.rb
+++ b/spec/unit/command/license_spec.rb
@@ -95,6 +95,7 @@ describe ChefCLI::Command::License do
 
         # Mocks the user prompt to enter the license
         allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(new_key)
+        allow(ChefLicensing).to receive(:fetch_and_persist).and_return(new_key)
       end
 
       it "should create and stores the new license" do

--- a/spec/unit/command/license_spec.rb
+++ b/spec/unit/command/license_spec.rb
@@ -1,0 +1,152 @@
+#
+# Copyright:: Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-cli/command/license"
+require "shared/command_with_ui_object"
+require "chef-cli/licensing/base"
+
+describe ChefCLI::Command::License do
+  it_behaves_like "a command with a UI object"
+
+  let(:params) { [] }
+  let(:ui) { TestHelpers::TestUI.new }
+
+  let(:command) do
+    c = described_class.new
+    c.validate_params!(params)
+    c.ui = ui
+    c
+  end
+
+  it "disables debug by default" do
+    expect(command.debug?).to be(false)
+  end
+
+  context "invalid parameters passed" do
+    let(:multiple_params) { %w{add list} }
+    let(:invalid_command) { %w{not_a_subcommand} }
+
+    it "should fail with errors when multiple subcommands passed" do
+      expect(command.run(multiple_params)).to eq(1)
+    end
+
+    it "should fail for invalid argument" do
+      expect(command.run(invalid_command)).to eq(1)
+    end
+  end
+
+  context "license command" do
+    context "when pre-accepted license exists" do
+      let(:license_keys) { %w{tsmc-abcd} }
+
+      before(:each) do
+        allow(ChefLicensing).to receive(:fetch_and_persist).and_return(license_keys)
+      end
+
+      it "should be successful" do
+        expect { command.run(params) }.not_to raise_exception
+      end
+
+      it "should return the correct license key" do
+        expect(command.run(params)).to eq(license_keys)
+      end
+    end
+
+    context "when no licenses are accepted previously" do
+      let(:new_key) { ["tsmc-123456789"] }
+      before(:each) do
+        ChefLicensing.configure do |config|
+          config.license_server_url = "https://license.test"
+          config.license_server_api_key = "token-123"
+          config.chef_product_name = "chef"
+          config.chef_entitlement_id = "chef-entitled-id"
+          config.chef_executable_name = "chef"
+        end
+
+        # Disable the active license check
+        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:licenses_active?).and_return(false)
+        # Disable the UI engine
+        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:append_extra_info_to_tui_engine)
+        # Disable the API call to fetch the license type
+        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:get_license_type).and_return("free")
+        # Disable the overwriting to the license.yml file
+        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::File).to receive(:persist)
+
+        # Mocks the user prompt to enter the license
+        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(new_key)
+      end
+
+      it "should create and stores the new license" do
+        expect { command.run(params) }.not_to raise_exception
+      end
+
+      it "should be same as the user entered license" do
+        expect(command.run(params)).to eq(new_key)
+      end
+    end
+  end
+
+  context "chef license list command" do
+    let(:params) { %w{list} }
+    let(:license_key) { "tsmn-123123" }
+
+    before do
+      command.ui = ui
+    end
+
+    context "when no licenses are accepted" do
+      it "should return the correct error message" do
+        expect(command.run(params)).to eq(0)
+
+        expect(ui.output).to eq("No license keys found on disk.")
+      end
+    end
+
+    context "when there is a valid license" do
+      before do
+        allow(ChefLicensing).to receive(:list_license_keys_info).and_return(license_key)
+      end
+
+      it "should print the license details" do
+        expect(command.run(params)).to eq(license_key)
+      end
+    end
+  end
+
+  context "chef license add command" do
+    let(:params) { %w{add} }
+    let(:license_key) { ["tsmn-123123"] }
+
+    before do
+      # Disable the API call to fetch the license type
+      allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:get_license_type).and_return("free")
+      # Disable the overwriting to the license.yml file
+      allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::File).to receive(:persist)
+      # Mocks the user prompt to enter the license
+      allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(license_key)
+    end
+
+    it "should not raise any errors" do
+      expect { command.run(params) }.not_to raise_exception
+    end
+
+    it "should create and store the new license" do
+      expect(command.run(params)).to eq(license_key)
+    end
+  end
+end

--- a/spec/unit/command/license_spec.rb
+++ b/spec/unit/command/license_spec.rb
@@ -26,6 +26,14 @@ describe ChefCLI::Command::License do
   let(:params) { [] }
   let(:ui) { TestHelpers::TestUI.new }
 
+  before do
+    allow(ChefCLI::Licensing::Base).to receive(:feature_enabled?).and_return(true)
+    # Disable the access of local licenses
+    allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_arg).and_return([])
+    allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_env).and_return([])
+    allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_from_file).and_return([])
+  end
+
   let(:command) do
     c = described_class.new
     c.validate_params!(params)
@@ -110,10 +118,13 @@ describe ChefCLI::Command::License do
     end
 
     context "when no licenses are accepted" do
-      it "should return the correct error message" do
-        expect(command.run(params)).to eq(0)
+      before do
+        allow_any_instance_of(ChefLicensing::ListLicenseKeys).to receive(:fetch_license_keys).and_return([])
+        allow_any_instance_of(ChefLicensing::ListLicenseKeys).to receive(:fetch_licenses_metadata).and_return([])
+      end
 
-        expect(ui.output).to eq("No license keys found on disk.")
+      it "should return the correct error message" do
+        expect(command.run(params)).to eq([])
       end
     end
 

--- a/spec/unit/command/license_spec.rb
+++ b/spec/unit/command/license_spec.rb
@@ -27,11 +27,10 @@ describe ChefCLI::Command::License do
   let(:ui) { TestHelpers::TestUI.new }
 
   before do
-    allow(ChefCLI::Licensing::Base).to receive(:feature_enabled?).and_return(true)
     # Disable the access of local licenses
     allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_arg).and_return([])
     allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_env).and_return([])
-    allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_from_file).and_return([])
+    allow_any_instance_of(ChefLicensing::LicensingService::Local).to receive(:detected?).and_return(false)
   end
 
   let(:command) do
@@ -80,7 +79,6 @@ describe ChefCLI::Command::License do
       before(:each) do
         ChefLicensing.configure do |config|
           config.license_server_url = "https://license.test"
-          config.license_server_api_key = "token-123"
           config.chef_product_name = "chef"
           config.chef_entitlement_id = "chef-entitled-id"
           config.chef_executable_name = "chef"
@@ -104,7 +102,7 @@ describe ChefCLI::Command::License do
       end
 
       it "should be same as the user entered license" do
-        expect(command.run(params)).to eq(new_key)
+        expect(command.run(params)).to include(new_key.first)
       end
     end
   end
@@ -157,7 +155,7 @@ describe ChefCLI::Command::License do
     end
 
     it "should create and store the new license" do
-      expect(command.run(params)).to eq(license_key)
+      expect(command.run(params)).to include(license_key.first)
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR will add the `chef license` command which can be used to generate the free/trial license for the chef infra. Also if the user has a commercial license, this command can be used to add that as well. 

Commands:
- `chef license`
- `chef license add`
- `chef license list`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
