### PR TITLE
CHEF-1533 Add check for co-located generator and cookbook

### DIFF
--- a/lib/chef-cli/chef_runner.rb
+++ b/lib/chef-cli/chef_runner.rb
@@ -41,7 +41,7 @@ module ChefCLI
     def converge
       configure
       Chef::Runner.new(run_context).converge
-    rescue Chef::Exceptions::CookbookNotFoundInRepo => e
+    rescue Chef::Exceptions::CookbookNotFound => e
       message = "Could not find cookbook(s) to satisfy run list #{run_list.inspect} in #{cookbook_path}"
       raise CookbookNotFound.new(message, e)
     rescue => e

--- a/lib/chef-cli/chef_runner.rb
+++ b/lib/chef-cli/chef_runner.rb
@@ -41,7 +41,7 @@ module ChefCLI
     def converge
       configure
       Chef::Runner.new(run_context).converge
-    rescue Chef::Exceptions::CookbookNotFound => e
+    rescue Chef::Exceptions::CookbookNotFoundInRepo => e
       message = "Could not find cookbook(s) to satisfy run list #{run_list.inspect} in #{cookbook_path}"
       raise CookbookNotFound.new(message, e)
     rescue => e

--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -210,8 +210,8 @@ module ChefCLI
           end
 
           if !generator_cookbook_path.empty? &&
-             !cookbook_full_path.empty? &&
-             File.identical?(Pathname.new(cookbook_full_path).parent, generator_cookbook_path)
+              !cookbook_full_path.empty? &&
+              File.identical?(Pathname.new(cookbook_full_path).parent, generator_cookbook_path)
             err("The generator and the cookbook cannot be in the same directory. Please specify a cookbook directory that is different from the generator's parent.")
             @params_valid = false
           end

--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -180,7 +180,11 @@ module ChefCLI
         end
 
         def cookbook_full_path
-          File.expand_path(cookbook_name_or_path, Dir.pwd)
+          if !cookbook_name_or_path.nil? && !cookbook_name_or_path.empty?
+            File.expand_path(cookbook_name_or_path, Dir.pwd)
+          else
+            ""
+          end
         end
 
         def policy_mode?
@@ -203,6 +207,11 @@ module ChefCLI
             @params_valid = false
           elsif File.basename(@cookbook_name_or_path).include?("-")
             msg("Hyphens are discouraged in cookbook names as they may cause problems with custom resources. See https://docs.chef.io/workstation/ctl_chef/#chef-generate-cookbook for more information.")
+          end
+
+          if File.identical?(Pathname.new(cookbook_full_path).parent, generator_cookbook_path)
+            err("The generator and the cookbook cannot be in the same directory. Please specify a cookbook directory that is different from the generator's parent.")
+            @params_valid = false
           end
 
           if config[:berks] && config[:policy]

--- a/lib/chef-cli/command/generator_commands/cookbook.rb
+++ b/lib/chef-cli/command/generator_commands/cookbook.rb
@@ -209,7 +209,9 @@ module ChefCLI
             msg("Hyphens are discouraged in cookbook names as they may cause problems with custom resources. See https://docs.chef.io/workstation/ctl_chef/#chef-generate-cookbook for more information.")
           end
 
-          if File.identical?(Pathname.new(cookbook_full_path).parent, generator_cookbook_path)
+          if !generator_cookbook_path.empty? &&
+             !cookbook_full_path.empty? &&
+             File.identical?(Pathname.new(cookbook_full_path).parent, generator_cookbook_path)
             err("The generator and the cookbook cannot be in the same directory. Please specify a cookbook directory that is different from the generator's parent.")
             @params_valid = false
           end

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -117,7 +117,7 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
 
   include_examples "custom generator cookbook" do
 
-    let(:generator_arg) { "nested/new_cookbook" }
+    let(:generator_arg) { "new_cookbook" }
 
     let(:generator_name) { "cookbook" }
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -152,6 +152,12 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
       expect(stderr_io.string).to include(message)
     end
 
+    it "errors if cookbook parent folder is same as generator parent folder" do
+      expect(with_argv(%w{ my_cookbook -g my_generator }).run).to eq(1)
+      message = "The generator and the cookbook cannot be in the same directory. Please specify a cookbook directory that is different from the generator's parent."
+      expect(stderr_io.string).to include(message)
+    end
+
     it "warns if a hyphenated cookbook name is passed" do
       expect(with_argv(%w{my-cookbook}).run).to eq(0)
       message = "Hyphens are discouraged in cookbook names as they may cause problems with custom resources. See https://docs.chef.io/workstation/ctl_chef/#chef-generate-cookbook for more information."

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -117,7 +117,7 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
 
   include_examples "custom generator cookbook" do
 
-    let(:generator_arg) { "new_cookbook" }
+    let(:generator_arg) { "nested/new_cookbook" }
 
     let(:generator_name) { "cookbook" }
 


### PR DESCRIPTION
## Description
Specifying a cookbook generator in the same path as the intended cookbook results in errors. Since this isn't good practice, the idea here is to check sooner and bail out.

## Related Issue
https://github.com/chef/chef-cli/issues/61

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
