### PR TITLE
Updated ffi-yajl dependency limit

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-cli", ">= 1.7", "< 3.0"
   gem.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
-  gem.add_dependency "ffi-yajl", ">= 1.0", "< 4.0"
+  gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
   gem.add_dependency "minitar", "~> 0.6"
   gem.add_dependency "chef", ">= 16.0"
   gem.add_dependency "solve", "< 5.0", "> 2.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updated the ffi-yajl dependency limit from < 4.0 to < 3.0. When using it <4.0 range it is failing with the below error

<img width="1080" alt="image" src="https://github.com/chef/chef-cli/assets/35272911/44d4b412-32e2-4a45-a416-f0d09bc87c4f">



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
