### PR TITLE
updated the undo path for windows

### DIFF
--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -144,7 +144,7 @@ module ChefCLI
 
     def default_package_home
       if Chef::Platform.windows?
-        File.join(ENV["LOCALAPPDATA"], ChefCLI::Dist::PRODUCT_PKG_HOME)
+        File.join(ENV["LOCALAPPDATA"], ChefCLI::Dist::PRODUCT_PKG_HOME).gsub('\\','/')
       else
         File.expand_path("~/.#{ChefCLI::Dist::PRODUCT_PKG_HOME}")
       end


### PR DESCRIPTION

## Description
Updated the undo path slashes for undelete command from backslash to forward slash as it was unable to find the files in windows OS

Prev path - `"C:\\Users\\Administrator\\AppData\\Local\\chef-workstation\\undo"`
Updated - `"C:/Users/Administrator/AppData/Local/chef-workstation/undo"`

## Related Issue
https://chefio.atlassian.net/browse/CHEF-1540

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
