### PR TITLE
Updated the undo path(from '\\' to "/") for undelete command for windows OS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem "rspec-mocks", "~> 3.8"
   gem "cookstyle", "=7.7.2" # this forces dependabot PRs to open which triggers cookstyle CI on the chef generate command
   gem "chefstyle", "=1.6.2"
-  gem "test-kitchen", ">= 2.11.1"
+  gem "test-kitchen", "=3.5.1"
 
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "~> 14"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem "rspec-mocks", "~> 3.8"
   gem "cookstyle", "=7.7.2" # this forces dependabot PRs to open which triggers cookstyle CI on the chef generate command
   gem "chefstyle", "=1.6.2"
-  gem "test-kitchen", "=3.5.1"
+  gem "test-kitchen", "=3.5.1" # pinning test-kitchen to 3.5.1 which supports ruby < 3.1 . Need to update this to latest once we update the ruby to 3.1 and chef to 18.x in chef-cli
 
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "~> 14"

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |gem|
   if RUBY_VERSION.match?(/3.1/)
     gem.add_dependency "chef", "~> 18.0"
   else
-    gem.add_dependency "chef", ">= 16.0"
+    gem.add_dependency "chef", "~> 17.0"
   end
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.9"

--- a/lib/chef-cli/helpers.rb
+++ b/lib/chef-cli/helpers.rb
@@ -144,7 +144,7 @@ module ChefCLI
 
     def default_package_home
       if Chef::Platform.windows?
-        File.join(ENV["LOCALAPPDATA"], ChefCLI::Dist::PRODUCT_PKG_HOME)
+        File.join(ENV["LOCALAPPDATA"], ChefCLI::Dist::PRODUCT_PKG_HOME).gsub("\\", "/")
       else
         File.expand_path("~/.#{ChefCLI::Dist::PRODUCT_PKG_HOME}")
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updated the undo path slashes for undelete command from backslash to forward slash as it was unable to find the files in windows OS

Prev path - `"C:\\Users\\Administrator\\AppData\\Local\\chef-workstation\\undo"`
Updated - `"C:/Users/Administrator/AppData/Local/chef-workstation/undo"`

<img width="985" alt="Screenshot 2023-12-13 at 3 16 13 PM" src="https://github.com/chef/chef-cli/assets/35272911/8d42a265-274b-4318-8915-238a62f0e2fb">

<img width="1217" alt="undelete-win-working-screenshot" src="https://github.com/chef/chef-cli/assets/35272911/cf216afc-d9f2-448d-8ceb-6bc2d9a97f62">

## Related Issue
https://chefio.atlassian.net/browse/CHEF-1540

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
