### PR TITLE
Update generator kitchen templates for modern platforms

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,32 +11,32 @@ expeditor:
 
 steps:
 
-- label: run-specs-ruby-2.7
+- label: run-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rspec
   expeditor:
     executor:
       docker:
-        image: ruby:2.7
+        image: ruby:3.1
 
-- label: run-specs-ruby-3.0
+- label: run-specs-ruby-3.3
   command:
     - .expeditor/run_linux_tests.sh rspec
   expeditor:
     executor:
       docker:
-        image: ruby:3.0
+        image: ruby:3.3
 
-- label: run-specs-windows-2.7
+- label: run-specs-windows-3.1
   command:
     - powershell .expeditor/run_windows_tests.ps1 rspec
   expeditor:
     executor:
       docker:
         host_os: windows
-        image: rubydistros/windows-2019:2.7
+        image: rubydistros/windows-2019:3.1
 
-- label: run-specs-windows-ruby-3.0
+- label: run-specs-windows-ruby-3.3
   command:
     - powershell .expeditor/run_windows_tests.ps1 rspec
   expeditor:
@@ -44,20 +44,20 @@ steps:
       docker:
         host_os: windows
         shell: ["powershell", "-Command"]
-        image: rubydistros/windows-2019:3.0
+        image: rubydistros/windows-2019:3.3
 
-- label: cookstyle-generator-cb-tests-ruby-2.7
+- label: cookstyle-generator-cb-tests-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh "rake style:cookstyle"
   expeditor:
     executor:
       docker:
-        image: ruby:2.7
+        image: ruby:3.1
 
-- label: chefstyle-tests-ruby-2.7
+- label: chefstyle-tests-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh "rake style:chefstyle"
   expeditor:
     executor:
       docker:
-        image: ruby:2.7
+        image: ruby:3.1

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ip-range-controlled
 #    needs: [build]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up ruby 3.1
         uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
   TargetRubyVersion: 3.1
   Include:
       - "**/*.rb"
-    Exclude:
+  Exclude:
       - "vendor/**/*"
       - "spec/**/*"
 Style/StringLiterals:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,14 @@
+---
+require:
+  - chefstyle
+
+AllCops:
+  TargetRubyVersion: 3.1
+  Include:
+      - "**/*.rb"
+    Exclude:
+      - "vendor/**/*"
+      - "spec/**/*"
 Style/StringLiterals:
   Exclude:
     - "spec/unit/fixtures/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -2,24 +2,16 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "logger", "< 1.6" # 1.6 causes errors with mixlib-log < 3.1.1
+
 group :test do
   gem "rake"
   gem "rspec", "~> 3.8"
   gem "rspec-expectations", "~> 3.8"
   gem "rspec-mocks", "~> 3.8"
-  gem "cookstyle", "=7.7.2" # this forces dependabot PRs to open which triggers cookstyle CI on the chef generate command
-  gem "chefstyle", "=1.6.2"
-  gem "test-kitchen", "=3.5.1" # pinning test-kitchen to 3.5.1 which supports ruby < 3.1 . Need to update this to latest once we update the ruby to 3.1 and chef to 18.x in chef-cli
-
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
-    gem "chef-zero", "~> 14"
-    gem "chef", "~> 15"
-    gem "chef-utils", "=16.6.14"
-  end
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
-    gem "ohai", "~> 16"
-  end
-
+  gem "cookstyle"
+  gem "chefstyle"
+  gem "test-kitchen"
   gem "simplecov", require: false
 end
 

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -43,11 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
   gem.add_dependency "minitar", "~> 0.6"
-  if RUBY_VERSION.match?(/3.1/)
-    gem.add_dependency "chef", "~> 18.0"
-  else
-    gem.add_dependency "chef", "~> 17.0"
-  end
+  gem.add_dependency "chef", "~> 18.0"
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.9"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"

--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
   gem.homepage      = "https://www.chef.io/"
 
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 3.1"
 
   gem.files = %w{Rakefile LICENSE} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks

--- a/lib/chef-cli/command/clean_policy_cookbooks.rb
+++ b/lib/chef-cli/command/clean_policy_cookbooks.rb
@@ -70,7 +70,7 @@ module ChefCLI
 
       def clean_policy_cookbooks_service
         @clean_policy_cookbooks_service ||=
-          PolicyfileServices::CleanPolicyCookbooks.new(config: chef_config, ui: ui)
+          PolicyfileServices::CleanPolicyCookbooks.new(config: chef_config, ui:)
       end
 
       def debug?

--- a/lib/chef-cli/command/clean_policy_revisions.rb
+++ b/lib/chef-cli/command/clean_policy_revisions.rb
@@ -67,7 +67,7 @@ module ChefCLI
 
       def clean_policies_service
         @policy_list_service ||=
-          PolicyfileServices::CleanPolicies.new(config: chef_config, ui: ui)
+          PolicyfileServices::CleanPolicies.new(config: chef_config, ui:)
       end
 
       def debug?

--- a/lib/chef-cli/command/delete_policy.rb
+++ b/lib/chef-cli/command/delete_policy.rb
@@ -69,8 +69,8 @@ module ChefCLI
       def rm_policy_service
         @rm_policy_service ||=
           PolicyfileServices::RmPolicy.new(config: chef_config,
-                                           ui: ui,
-                                           policy_name: policy_name)
+                                           ui:,
+                                           policy_name:)
       end
 
       def debug?

--- a/lib/chef-cli/command/delete_policy_group.rb
+++ b/lib/chef-cli/command/delete_policy_group.rb
@@ -69,8 +69,8 @@ module ChefCLI
       def rm_policy_group_service
         @rm_policy_group_service ||=
           PolicyfileServices::RmPolicyGroup.new(config: chef_config,
-                                                ui: ui,
-                                                policy_group: policy_group)
+                                                ui:,
+                                                policy_group:)
       end
 
       def debug?

--- a/lib/chef-cli/command/diff.rb
+++ b/lib/chef-cli/command/diff.rb
@@ -145,10 +145,10 @@ module ChefCLI
 
       def differ(ui = self.ui)
         Policyfile::Differ.new(old_name: old_base.name,
-                               old_lock: old_lock,
+                               old_lock:,
                                new_name: new_base.name,
-                               new_lock: new_lock,
-                               ui: ui)
+                               new_lock:,
+                               ui:)
       end
 
       def http_client

--- a/lib/chef-cli/command/export.rb
+++ b/lib/chef-cli/command/export.rb
@@ -127,7 +127,7 @@ module ChefCLI
       def export_service
         @export_service ||= PolicyfileServices::ExportRepo.new(
           policyfile: policyfile_relative_path,
-          export_dir: export_dir,
+          export_dir:,
           root_dir: Dir.pwd,
           archive: archive?,
           force: config[:force],

--- a/lib/chef-cli/command/install.rb
+++ b/lib/chef-cli/command/install.rb
@@ -74,7 +74,7 @@ module ChefCLI
       end
 
       def installer
-        @installer ||= PolicyfileServices::Install.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd, config: chef_config)
+        @installer ||= PolicyfileServices::Install.new(policyfile: policyfile_relative_path, ui:, root_dir: Dir.pwd, config: chef_config)
       end
 
       def debug?

--- a/lib/chef-cli/command/push.rb
+++ b/lib/chef-cli/command/push.rb
@@ -84,8 +84,8 @@ module ChefCLI
 
       def push
         @push ||= PolicyfileServices::Push.new(policyfile: policyfile_relative_path,
-                                               ui: ui,
-                                               policy_group: policy_group,
+                                               ui:,
+                                               policy_group:,
                                                config: chef_config,
                                                root_dir: Dir.pwd)
       end

--- a/lib/chef-cli/command/push_archive.rb
+++ b/lib/chef-cli/command/push_archive.rb
@@ -83,9 +83,9 @@ module ChefCLI
       def push_archive_service
         @push_archive_service ||=
           ChefCLI::PolicyfileServices::PushArchive.new(
-            archive_file: archive_file,
-            policy_group: policy_group,
-            ui: ui,
+            archive_file:,
+            policy_group:,
+            ui:,
             config: chef_config
           )
       end

--- a/lib/chef-cli/command/show_policy.rb
+++ b/lib/chef-cli/command/show_policy.rb
@@ -87,9 +87,9 @@ module ChefCLI
       def show_policy_service
         @policy_list_service ||=
           PolicyfileServices::ShowPolicy.new(config: chef_config,
-                                             ui: ui,
-                                             policy_name: policy_name,
-                                             policy_group: policy_group,
+                                             ui:,
+                                             policy_name:,
+                                             policy_group:,
                                              show_orphans: show_orphans?,
                                              summary_diff: show_summary_diff?,
                                              pager: enable_pager?)

--- a/lib/chef-cli/command/undelete.rb
+++ b/lib/chef-cli/command/undelete.rb
@@ -93,8 +93,8 @@ module ChefCLI
       def undelete_service
         @undelete_service ||=
           PolicyfileServices::Undelete.new(config: chef_config,
-                                           ui: ui,
-                                           undo_record_id: undo_record_id)
+                                           ui:,
+                                           undo_record_id:)
       end
 
       def debug?

--- a/lib/chef-cli/command/update.rb
+++ b/lib/chef-cli/command/update.rb
@@ -100,12 +100,12 @@ module ChefCLI
       end
 
       def installer
-        @installer ||= PolicyfileServices::Install.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd, config: chef_config, overwrite: true)
+        @installer ||= PolicyfileServices::Install.new(policyfile: policyfile_relative_path, ui:, root_dir: Dir.pwd, config: chef_config, overwrite: true)
       end
 
       def attributes_updater
         @attributes_updater ||=
-          PolicyfileServices::UpdateAttributes.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd, chef_config: chef_config)
+          PolicyfileServices::UpdateAttributes.new(policyfile: policyfile_relative_path, ui:, root_dir: Dir.pwd, chef_config:)
       end
 
       def debug?

--- a/lib/chef-cli/policyfile/artifactory_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/artifactory_cookbook_source.rb
@@ -54,14 +54,12 @@ module ChefCLI
       end
 
       def universe_graph
-        @universe_graph ||= begin
-          full_community_graph.inject({}) do |normalized_graph, (cookbook_name, metadata_by_version)|
-            normalized_graph[cookbook_name] = metadata_by_version.inject({}) do |deps_by_version, (version, metadata)|
-              deps_by_version[version] = metadata["dependencies"]
-              deps_by_version
-            end
-            normalized_graph
+        @universe_graph ||= full_community_graph.inject({}) do |normalized_graph, (cookbook_name, metadata_by_version)|
+          normalized_graph[cookbook_name] = metadata_by_version.inject({}) do |deps_by_version, (version, metadata)|
+            deps_by_version[version] = metadata["dependencies"]
+            deps_by_version
           end
+          normalized_graph
         end
       end
 
@@ -90,7 +88,7 @@ module ChefCLI
 
       def http_connection_for(base_url)
         headers = { "X-Jfrog-Art-API" => artifactory_api_key }
-        @http_connections[base_url] ||= Chef::HTTP::Simple.new(base_url, headers: headers)
+        @http_connections[base_url] ||= Chef::HTTP::Simple.new(base_url, headers:)
       end
 
       def full_community_graph

--- a/lib/chef-cli/policyfile/chef_server_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/chef_server_cookbook_source.rb
@@ -52,14 +52,12 @@ module ChefCLI
       end
 
       def universe_graph
-        @universe_graph ||= begin
-          full_chef_server_graph.inject({}) do |normalized_graph, (cookbook_name, metadata_by_version)|
-            normalized_graph[cookbook_name] = metadata_by_version.inject({}) do |deps_by_version, (version, metadata)|
-              deps_by_version[version] = metadata["dependencies"]
-              deps_by_version
-            end
-            normalized_graph
+        @universe_graph ||= full_chef_server_graph.inject({}) do |normalized_graph, (cookbook_name, metadata_by_version)|
+          normalized_graph[cookbook_name] = metadata_by_version.inject({}) do |deps_by_version, (version, metadata)|
+            deps_by_version[version] = metadata["dependencies"]
+            deps_by_version
           end
+          normalized_graph
         end
       end
 
@@ -90,9 +88,7 @@ module ChefCLI
 
       def full_chef_server_graph
         @full_chef_server_graph ||=
-          begin
-            http_connection_for(uri.to_s).get("/universe")
-          end
+          http_connection_for(uri.to_s).get("/universe")
       end
     end
   end

--- a/lib/chef-cli/policyfile/community_cookbook_source.rb
+++ b/lib/chef-cli/policyfile/community_cookbook_source.rb
@@ -52,14 +52,12 @@ module ChefCLI
       end
 
       def universe_graph
-        @universe_graph ||= begin
-          full_community_graph.inject({}) do |normalized_graph, (cookbook_name, metadata_by_version)|
-            normalized_graph[cookbook_name] = metadata_by_version.inject({}) do |deps_by_version, (version, metadata)|
-              deps_by_version[version] = metadata["dependencies"]
-              deps_by_version
-            end
-            normalized_graph
+        @universe_graph ||= full_community_graph.inject({}) do |normalized_graph, (cookbook_name, metadata_by_version)|
+          normalized_graph[cookbook_name] = metadata_by_version.inject({}) do |deps_by_version, (version, metadata)|
+            deps_by_version[version] = metadata["dependencies"]
+            deps_by_version
           end
+          normalized_graph
         end
       end
 

--- a/lib/chef-cli/policyfile/delivery_supermarket_source.rb
+++ b/lib/chef-cli/policyfile/delivery_supermarket_source.rb
@@ -66,15 +66,13 @@ module ChefCLI
       end
 
       def universe_graph
-        @universe_graph ||= begin
-          @community_source.universe_graph.inject({}) do |truncated, (cookbook_name, version_and_deps_list)|
-            sorted_versions = version_and_deps_list.keys.sort_by do |version_string|
-              Semverse::Version.new(version_string)
-            end
-            greatest_version = sorted_versions.last
-            truncated[cookbook_name] = { greatest_version => version_and_deps_list[greatest_version] }
-            truncated
+        @universe_graph ||= @community_source.universe_graph.inject({}) do |truncated, (cookbook_name, version_and_deps_list)|
+          sorted_versions = version_and_deps_list.keys.sort_by do |version_string|
+            Semverse::Version.new(version_string)
           end
+          greatest_version = sorted_versions.last
+          truncated[cookbook_name] = { greatest_version => version_and_deps_list[greatest_version] }
+          truncated
         end
       end
 

--- a/lib/chef-cli/policyfile/dsl.rb
+++ b/lib/chef-cli/policyfile/dsl.rb
@@ -27,7 +27,7 @@ module ChefCLI
   module Policyfile
     class DSL
 
-      RUN_LIST_ITEM_COMPONENT = /^[.[:alnum:]_-]+$/.freeze
+      RUN_LIST_ITEM_COMPONENT = /^[.[:alnum:]_-]+$/
 
       include StorageConfigDelegation
 
@@ -203,7 +203,7 @@ module ChefCLI
         if source_uri.nil?
           @errors << "You must specify the server's URI when using a default_source :chef_server"
         else
-          set_default_source(ChefServerCookbookSource.new(source_uri, chef_config: chef_config, &block))
+          set_default_source(ChefServerCookbookSource.new(source_uri, chef_config:, &block))
         end
       end
 
@@ -211,7 +211,7 @@ module ChefCLI
         if source_uri.nil?
           @errors << "You must specify the server's URI when using a default_source :artifactory"
         else
-          set_default_source(ArtifactoryCookbookSource.new(source_uri, chef_config: chef_config, &block))
+          set_default_source(ArtifactoryCookbookSource.new(source_uri, chef_config:, &block))
         end
       end
 

--- a/lib/chef-cli/policyfile/git_lock_fetcher.rb
+++ b/lib/chef-cli/policyfile/git_lock_fetcher.rb
@@ -87,7 +87,7 @@ module ChefCLI
       # @return [Hash] The source_options that describe how to fetch this exact lock again
       def source_options_for_lock
         source_options.merge({
-                               revision: revision,
+                               revision:,
                              })
       end
 

--- a/lib/chef-cli/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-cli/policyfile/policyfile_location_specification.rb
@@ -62,20 +62,18 @@ module ChefCLI
 
       # @return A policyfile lock fetcher compatible with the given source_options
       def fetcher
-        @fetcher ||= begin
-                       if source_options[:path] && !source_options[:git]
-                         Policyfile::LocalLockFetcher.new(name, source_options, storage_config)
-                       elsif source_options[:remote]
-                         Policyfile::RemoteLockFetcher.new(name, source_options)
-                       elsif source_options[:server]
-                         Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
-                       elsif source_options[:git]
-                         Policyfile::GitLockFetcher.new(name, source_options, storage_config)
-                       else
-                         raise ChefCLI::InvalidPolicyfileLocation.new(
-                           "Invalid policyfile lock location type. The supported locations are: #{LOCATION_TYPES.join(", ")}"
-                         )
-                       end
+        @fetcher ||= if source_options[:path] && !source_options[:git]
+                       Policyfile::LocalLockFetcher.new(name, source_options, storage_config)
+                     elsif source_options[:remote]
+                       Policyfile::RemoteLockFetcher.new(name, source_options)
+                     elsif source_options[:server]
+                       Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
+                     elsif source_options[:git]
+                       Policyfile::GitLockFetcher.new(name, source_options, storage_config)
+                     else
+                       raise ChefCLI::InvalidPolicyfileLocation.new(
+                         "Invalid policyfile lock location type. The supported locations are: #{LOCATION_TYPES.join(", ")}"
+                       )
                      end
       end
 
@@ -106,9 +104,7 @@ module ChefCLI
       #
       # @return [PolicyfileLock] the loaded policyfile lock
       def policyfile_lock
-        @policyfile_lock ||= begin
-                               PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(fetcher.lock_data)
-                             end
+        @policyfile_lock ||= PolicyfileLock.new(storage_config, ui:).build_from_lock_data(fetcher.lock_data)
       end
 
       # @return [Hash] The source_options that describe how to fetch this exact lock again

--- a/lib/chef-cli/policyfile/solution_dependencies.rb
+++ b/lib/chef-cli/policyfile/solution_dependencies.rb
@@ -28,7 +28,7 @@ module ChefCLI
 
       class Cookbook
 
-        VALID_STRING_FORMAT = /\A[^\s]+ \([^\s]+\)\Z/.freeze
+        VALID_STRING_FORMAT = /\A[^\s]+ \([^\s]+\)\Z/
 
         def self.valid_str?(str)
           !!(str =~ VALID_STRING_FORMAT)

--- a/lib/chef-cli/policyfile/uploader.rb
+++ b/lib/chef-cli/policyfile/uploader.rb
@@ -207,7 +207,7 @@ module ChefCLI
           remote_already_has_cookbook?(cb_with_lock.cookbook)
         end
 
-        Reports::Upload.new(reused_cbs: reused_cbs, uploaded_cbs: uploaded_cbs, ui: ui).show
+        Reports::Upload.new(reused_cbs:, uploaded_cbs:, ui:).show
 
         true
       end

--- a/lib/chef-cli/policyfile_compiler.rb
+++ b/lib/chef-cli/policyfile_compiler.rb
@@ -42,7 +42,7 @@ module ChefCLI
     SOURCE_TYPES_WITH_FIXED_VERSIONS = %i{git path}.freeze
 
     def self.evaluate(policyfile_string, policyfile_filename, ui: nil, chef_config: nil)
-      compiler = new(ui: ui, chef_config: chef_config)
+      compiler = new(ui:, chef_config:)
       compiler.evaluate_policyfile(policyfile_string, policyfile_filename)
       compiler
     end
@@ -61,7 +61,7 @@ module ChefCLI
 
     def initialize(ui: nil, chef_config: nil)
       @storage_config = Policyfile::StorageConfig.new
-      @dsl = Policyfile::DSL.new(storage_config, chef_config: chef_config)
+      @dsl = Policyfile::DSL.new(storage_config, chef_config:)
       @artifact_server_cookbook_location_specs = {}
 
       @merged_graph = nil

--- a/lib/chef-cli/policyfile_lock.rb
+++ b/lib/chef-cli/policyfile_lock.rb
@@ -64,7 +64,7 @@ module ChefCLI
       end
     end
 
-    RUN_LIST_ITEM_FORMAT = /\Arecipe\[[^\s]+::[^\s]+\]\Z/.freeze
+    RUN_LIST_ITEM_FORMAT = /\Arecipe\[[^\s]+::[^\s]+\]\Z/
 
     def self.build(storage_config)
       lock = new(storage_config)

--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -121,12 +121,12 @@ module ChefCLI
         random_string = SecureRandom.hex(2)
         path = "chef-export-#{random_string}"
         Dir.mktmpdir(path) do |d|
-          begin
-            @staging_dir = d
-            yield
-          ensure
-            @staging_dir = nil
-          end
+
+          @staging_dir = d
+          yield
+        ensure
+          @staging_dir = nil
+
         end
       end
 

--- a/lib/chef-cli/policyfile_services/install.rb
+++ b/lib/chef-cli/policyfile_services/install.rb
@@ -73,7 +73,7 @@ module ChefCLI
       end
 
       def policyfile_compiler
-        @policyfile_compiler ||= ChefCLI::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui: ui, chef_config: chef_config)
+        @policyfile_compiler ||= ChefCLI::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui:, chef_config:)
       end
 
       def expanded_run_list
@@ -89,7 +89,7 @@ module ChefCLI
 
         @policyfile_lock ||= begin
           lock_data = FFI_Yajl::Parser.new.parse(policyfile_lock_content)
-          PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(lock_data)
+          PolicyfileLock.new(storage_config, ui:).build_from_lock_data(lock_data)
         end
       end
 

--- a/lib/chef-cli/policyfile_services/push.rb
+++ b/lib/chef-cli/policyfile_services/push.rb
@@ -64,8 +64,8 @@ module ChefCLI
 
       def uploader
         ChefCLI::Policyfile::Uploader.new(policyfile_lock, policy_group,
-          ui: ui,
-          http_client: http_client,
+          ui:,
+          http_client:,
           policy_document_native_api: config.policy_document_native_api)
       end
 

--- a/lib/chef-cli/policyfile_services/push_archive.rb
+++ b/lib/chef-cli/policyfile_services/push_archive.rb
@@ -69,8 +69,8 @@ module ChefCLI
       # @api private
       def uploader
         ChefCLI::Policyfile::Uploader.new(policyfile_lock, policy_group,
-          ui: ui,
-          http_client: http_client,
+          ui:,
+          http_client:,
           policy_document_native_api: config.policy_document_native_api)
       end
 

--- a/lib/chef-cli/policyfile_services/update_attributes.rb
+++ b/lib/chef-cli/policyfile_services/update_attributes.rb
@@ -78,7 +78,7 @@ module ChefCLI
       end
 
       def policyfile_compiler
-        @policyfile_compiler ||= ChefCLI::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui: ui, chef_config: chef_config)
+        @policyfile_compiler ||= ChefCLI::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui:, chef_config:)
       end
 
       def policyfile_lock_content
@@ -88,7 +88,7 @@ module ChefCLI
       def policyfile_lock
         @policyfile_lock ||= begin
           lock_data = FFI_Yajl::Parser.new.parse(policyfile_lock_content)
-          PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(lock_data)
+          PolicyfileLock.new(storage_config, ui:).build_from_lock_data(lock_data)
         end
       end
 

--- a/lib/chef-cli/skeletons/code_generator/files/default/repo/cookbooks/example/recipes/default.rb
+++ b/lib/chef-cli/skeletons/code_generator/files/default/repo/cookbooks/example/recipes/default.rb
@@ -1,7 +1,7 @@
 # This is a Chef Infra Client recipe file. It can be used to specify resources
 # which will apply configuration to a server.
 
-log "Welcome to Chef Infra Client, #{node['example']['name']}!" do
+log "Welcome to Chef Infra Client, #{node["example"]["name"]}!" do
   level :info
 end
 

--- a/lib/chef-cli/skeletons/code_generator/recipes/helpers.rb
+++ b/lib/chef-cli/skeletons/code_generator/recipes/helpers.rb
@@ -15,5 +15,5 @@ helper_class_name = "#{camelize(context.new_file_basename)}Helpers"
 template helpers_path do
   source 'helpers.rb.erb'
   helpers(ChefCLI::Generator::TemplateHelper)
-  variables(cookbook_class_name: cookbook_class_name, helper_class_name: helper_class_name)
+  variables(cookbook_class_name:, helper_class_name:)
 end

--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -10,7 +10,7 @@ driver:
 #    - ["forwarded_port", {guest: 80, host: 8080}]
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   # You may wish to disable always updating cookbooks in CI or other testing environments.
   # For example:
   #   always_update_cookbooks: <%%= !ENV['CI'] %>
@@ -19,14 +19,22 @@ provisioner:
   ## product_name and product_version specifies a specific Chef product and version to install.
   ## see the Chef documentation for more details: https://docs.chef.io/workstation/config_yml_kitchen/
   #  product_name: chef
-  #  product_version: 17
+  #  product_version: 18
 
 verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-20.04
-  - name: centos-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: debian-12
+  - name: fedora-latest
+  - name: freebsd-14
+  - name: opensuse-leap-15
+  - name: oraclelinux-9
+  - name: rockylinux-9
+  - name: ubuntu-24.04
 
 suites:
   - name: default

--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
@@ -15,17 +15,46 @@ verifier:
 platforms:
   # @see https://github.com/chef-cookbooks/testing_examples/blob/main/kitchen.dokken.yml
   # @see https://hub.docker.com/u/dokken
-  - name: ubuntu-20.04
+  - name: almalinux-9
     driver:
-      image: dokken/ubuntu-20.04
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2023
+    driver:
+      image: dokken/amazonlinux-2023
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-stream-9
+    driver:
+      image: dokken/centos-stream-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: debian-12
+    driver:
+      image: dokken/debian-12
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
-
-  - name: centos-8
+  - name: fedora-latest
     driver:
-      image: dokken/centos-8
+      image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
+  - name: opensuse-leap-15
+    driver:
+      image: dokken/opensuse-leap-15
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: oraclelinux-9
+    driver:
+      image: dokken/oraclelinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: rockylinux-9
+    driver:
+      image: dokken/rockylinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
 
 suites:
   - name: default

--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -10,19 +10,27 @@ driver:
 #    - ["forwarded_port", {guest: 80, host: 8080}]
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
 
   ## product_name and product_version specifies a specific Chef product and version to install.
   ## see the Chef documentation for more details: https://docs.chef.io/workstation/config_yml_kitchen/
   #  product_name: chef
-  #  product_version: 17
+  #  product_version: 18
 
 verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-20.04
-  - name: centos-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: debian-12
+  - name: fedora-latest
+  - name: freebsd-14
+  - name: opensuse-leap-15
+  - name: oraclelinux-9
+  - name: rockylinux-9
+  - name: ubuntu-24.04
 
 suites:
   - name: default

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -388,19 +388,27 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
             #    - ["forwarded_port", {guest: 80, host: 8080}]
 
             provisioner:
-              name: chef_zero
+              name: chef_infra
 
               ## product_name and product_version specifies a specific Chef product and version to install.
               ## see the Chef documentation for more details: https://docs.chef.io/workstation/config_yml_kitchen/
               #  product_name: chef
-              #  product_version: 17
+              #  product_version: 18
 
             verifier:
               name: inspec
 
             platforms:
-              - name: ubuntu-20.04
-              - name: centos-8
+              - name: almalinux-9
+              - name: amazonlinux-2023
+              - name: centos-stream-9
+              - name: debian-12
+              - name: fedora-latest
+              - name: freebsd-14
+              - name: opensuse-leap-15
+              - name: oraclelinux-9
+              - name: rockylinux-9
+              - name: ubuntu-24.04
 
             suites:
               - name: default
@@ -520,7 +528,7 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
             #    - ["forwarded_port", {guest: 80, host: 8080}]
 
             provisioner:
-              name: chef_zero
+              name: chef_infra
               # You may wish to disable always updating cookbooks in CI or other testing environments.
               # For example:
               #   always_update_cookbooks: <%= !ENV['CI'] %>
@@ -529,14 +537,22 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
               ## product_name and product_version specifies a specific Chef product and version to install.
               ## see the Chef documentation for more details: https://docs.chef.io/workstation/config_yml_kitchen/
               #  product_name: chef
-              #  product_version: 17
+              #  product_version: 18
 
             verifier:
               name: inspec
 
             platforms:
-              - name: ubuntu-20.04
-              - name: centos-8
+              - name: almalinux-9
+              - name: amazonlinux-2023
+              - name: centos-stream-9
+              - name: debian-12
+              - name: fedora-latest
+              - name: freebsd-14
+              - name: opensuse-leap-15
+              - name: oraclelinux-9
+              - name: rockylinux-9
+              - name: ubuntu-24.04
 
             suites:
               - name: default

--- a/spec/unit/command/generator_commands/repo_spec.rb
+++ b/spec/unit/command/generator_commands/repo_spec.rb
@@ -256,7 +256,7 @@ describe ChefCLI::Command::GeneratorCommands::Repo do
           let(:file) { "cookbooks/example/recipes/default.rb" }
 
           it "has the right contents" do
-            expect(file_contents).to match(/log "Welcome to Chef Infra Client, \#\{node\['example'\]\['name'\]\}!" do/)
+            expect(file_contents).to match(/log "Welcome to Chef Infra Client, \#\{node\["example"\]\["name"\]\}!" do/)
           end
         end
       end

--- a/spec/unit/policyfile_lock_serialization_spec.rb
+++ b/spec/unit/policyfile_lock_serialization_spec.rb
@@ -137,7 +137,7 @@ describe ChefCLI::PolicyfileLock, "when reading a Policyfile.lock" do
 
     it "requires the values in named_run_lists to be valid run lists" do
       bad_named_run_lists = valid_lock_data.dup
-      bad_named_run_lists["named_run_lists"] = { "bad" => [ 42 ] }
+      bad_named_run_lists["named_run_lists"] = { "bad" => [ "42" ] }
 
       expect { lockfile.build_from_lock_data(bad_named_run_lists) }.to raise_error(ChefCLI::InvalidLockfile)
     end

--- a/spec/unit/policyfile_services/clean_policies_spec.rb
+++ b/spec/unit/policyfile_services/clean_policies_spec.rb
@@ -215,7 +215,7 @@ describe ChefCLI::PolicyfileServices::CleanPolicies do
             # this will continue to print that out until they remove HTTPServerException
             expected_message = <<~ERROR
               Failed to delete some policy revisions:
-              - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPServerException 403 \"Unauthorized\"
+              - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPClientException 403 \"Unauthorized\"
             ERROR
 
             expect { clean_policies_service.run }.to raise_error do |error|


### PR DESCRIPTION
## Description

Updated the generator kitchen templates for latest chef_infra provisioner name, and update platforms for latest current versions now that centos is EOL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
