### PR TITLE
removing freebsd from kitchen.yml generator template

### DIFF
--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -30,7 +30,6 @@ platforms:
   - name: centos-stream-9
   - name: debian-12
   - name: fedora-latest
-  - name: freebsd-14
   - name: opensuse-leap-15
   - name: oraclelinux-9
   - name: rockylinux-9

--- a/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-cli/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -26,7 +26,6 @@ platforms:
   - name: centos-stream-9
   - name: debian-12
   - name: fedora-latest
-  - name: freebsd-14
   - name: opensuse-leap-15
   - name: oraclelinux-9
   - name: rockylinux-9

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -404,7 +404,6 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
               - name: centos-stream-9
               - name: debian-12
               - name: fedora-latest
-              - name: freebsd-14
               - name: opensuse-leap-15
               - name: oraclelinux-9
               - name: rockylinux-9
@@ -548,7 +547,6 @@ describe ChefCLI::Command::GeneratorCommands::Cookbook do
               - name: centos-stream-9
               - name: debian-12
               - name: fedora-latest
-              - name: freebsd-14
               - name: opensuse-leap-15
               - name: oraclelinux-9
               - name: rockylinux-9


### PR DESCRIPTION
## Description
Removing freebsd since it's not supported anymore by chef-client

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
