### PR TITLE
Upgrading diff-lcs dependency

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.9"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"
-  gem.add_dependency "diff-lcs", ">= 1.0", "< 1.4" # 1.4 changes the output
+  gem.add_dependency "diff-lcs", ">= 1.2.4", "!= 1.4.0", "< 1.6.0" # 1.4 breaks output. Used in lib/chef/util/diff
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
 end

--- a/spec/unit/policyfile/differ_spec.rb
+++ b/spec/unit/policyfile/differ_spec.rb
@@ -318,7 +318,7 @@ describe ChefCLI::Policyfile::Differ do
         REVISION ID CHANGED
         ===================
 
-        @@ -1,2 +1,2 @@
+        @@ -1 +1 @@
         -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
         +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 
@@ -369,7 +369,7 @@ describe ChefCLI::Policyfile::Differ do
           REVISION ID CHANGED
           ===================
 
-          @@ -1,2 +1,2 @@
+          @@ -1 +1 @@
           -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
           +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 
@@ -428,7 +428,7 @@ describe ChefCLI::Policyfile::Differ do
         REVISION ID CHANGED
         ===================
 
-        @@ -1,2 +1,2 @@
+        @@ -1 +1 @@
         -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
         +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 
@@ -501,7 +501,7 @@ describe ChefCLI::Policyfile::Differ do
         REVISION ID CHANGED
         ===================
 
-        @@ -1,2 +1,2 @@
+        @@ -1 +1 @@
         -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
         +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 
@@ -511,7 +511,7 @@ describe ChefCLI::Policyfile::Differ do
         bluepill
         --------
 
-        @@ -1 +1,12 @@
+        @@ -1,11 +1,22 @@
         +{
         +  "version": "2.3.2",
         +  "identifier": "9c6990944d9a347dec8bd375e707ba0aecdc17cd",
@@ -563,7 +563,7 @@ describe ChefCLI::Policyfile::Differ do
         REVISION ID CHANGED
         ===================
 
-        @@ -1,2 +1,2 @@
+        @@ -1 +1 @@
         -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
         +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 
@@ -616,7 +616,7 @@ describe ChefCLI::Policyfile::Differ do
         REVISION ID CHANGED
         ===================
 
-        @@ -1,2 +1,2 @@
+        @@ -1 +1 @@
         -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
         +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 
@@ -662,7 +662,7 @@ describe ChefCLI::Policyfile::Differ do
         REVISION ID CHANGED
         ===================
 
-        @@ -1,2 +1,2 @@
+        @@ -1 +1 @@
         -cf4b8a020bdc1ba6914093a8a07a5514cce8a3a2979a967b1f32ea704a61785b
         +304566f86a620aae85797a3c491a51fb8c6ecf996407e77b8063aa3ee59672c5
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updadtng diff-lcs dependency to latest since we are updating test-kitchen to latest 3.7.0 in Workstation and this test-kitchen version depends on cucumber >= 9.2 which depends on diff-lcs ~> 1.5, so we need to update this dependency in chef-cli first.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
