### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,4 +1,6 @@
 name: SonarQube scan
+permissions:
+  contents: read
 on:
   # Trigger analysis when pushing to your main branches, and when creating a pull request.
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chef/chef-cli/security/code-scanning/30](https://github.com/chef/chef-cli/security/code-scanning/30)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required for the SonarQube scan. Since the workflow only needs to read the repository contents, we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privileges necessary to perform the task.

The `permissions` block will be added at the root of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
