### PR TITLE
Updating the minitar dependency in chef-cli-5

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-cli", ">= 1.7", "< 3.0"
   gem.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
-  gem.add_dependency "minitar", "~> 0.6"
+  gem.add_dependency "minitar", "~> 1.0"
   gem.add_dependency "chef", "~> 18.0"
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.9"

--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -20,7 +20,7 @@ require "fileutils" unless defined?(FileUtils)
 require "tmpdir" unless defined?(Dir.mktmpdir)
 require "zlib" unless defined?(Zlib)
 
-require "archive/tar/minitar"
+require 'minitar'
 
 require "chef/cookbook/chefignore"
 

--- a/lib/chef-cli/policyfile_services/export_repo.rb
+++ b/lib/chef-cli/policyfile_services/export_repo.rb
@@ -20,7 +20,7 @@ require "fileutils" unless defined?(FileUtils)
 require "tmpdir" unless defined?(Dir.mktmpdir)
 require "zlib" unless defined?(Zlib)
 
-require 'minitar'
+require "minitar"
 
 require "chef/cookbook/chefignore"
 

--- a/lib/chef-cli/policyfile_services/push_archive.rb
+++ b/lib/chef-cli/policyfile_services/push_archive.rb
@@ -16,7 +16,7 @@
 #
 
 require "zlib" unless defined?(Zlib)
-require 'minitar'
+require "minitar"
 
 require_relative "../service_exceptions"
 require_relative "../policyfile_lock"

--- a/lib/chef-cli/policyfile_services/push_archive.rb
+++ b/lib/chef-cli/policyfile_services/push_archive.rb
@@ -16,7 +16,7 @@
 #
 
 require "zlib" unless defined?(Zlib)
-require "archive/tar/minitar"
+require 'minitar'
 
 require_relative "../service_exceptions"
 require_relative "../policyfile_lock"

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -24,7 +24,7 @@ describe ChefCLI::PolicyfileServices::PushArchive do
 
   def create_archive
     Zlib::GzipWriter.open(archive_file_path) do |gz_file|
-      Archive::Tar::Minitar::Writer.open(gz_file) do |tar|
+      Minitar::Writer.open(gz_file) do |tar|
 
         archive_dirs.each do |dir|
           tar.mkdir(dir, mode: 0755)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the minitar dependency to "~> 1.0" in chef-cli-5 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
