### PR TITLE
[CHEF-21374] Removed the chef-cli license command

### DIFF
--- a/chef-cli.gemspec
+++ b/chef-cli.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", ">= 1.2.4", "!= 1.4.0", "< 1.6.0" # 1.4 breaks output. Used in lib/chef/util/diff
   gem.add_dependency "pastel", "~> 0.7" # used for policyfile differ
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3"
-  gem.add_dependency "chef-licensing", "~> 1.0"
+  # gem.add_dependency "chef-licensing", "~> 1.0"
 end

--- a/lib/chef-cli/builtin_commands.rb
+++ b/lib/chef-cli/builtin_commands.rb
@@ -57,6 +57,6 @@ ChefCLI.commands do |c|
 
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-cli/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
-  c.builtin "license", :License, require_path: "chef-cli/command/license",
-            desc: "Create & install a new license on the system or view installed license(s)."
+  # c.builtin "license", :License, require_path: "chef-cli/command/license",
+  #           desc: "Create & install a new license on the system or view installed license(s)."
 end

--- a/lib/chef-cli/command/license.rb
+++ b/lib/chef-cli/command/license.rb
@@ -16,95 +16,95 @@
 # limitations under the License.
 #
 
-require_relative "base"
-require "chef-cli/licensing/base"
-require_relative "../configurable"
+# require_relative "base"
+# require "chef-cli/licensing/base"
+# require_relative "../configurable"
 
-module ChefCLI
-  module Command
+# module ChefCLI
+#   module Command
 
-    # This class will manage the license command in the chef-cli
-    class License < Base
+#     # This class will manage the license command in the chef-cli
+#     class License < Base
 
-      include Configurable
+#       include Configurable
 
-      MAIN_COMMAND_HELP = <<~HELP.freeze
-        Usage: #{ChefCLI::Dist::EXEC} license [SUBCOMMAND]
+#       MAIN_COMMAND_HELP = <<~HELP.freeze
+#         Usage: #{ChefCLI::Dist::EXEC} license [SUBCOMMAND]
 
-        `#{ChefCLI::Dist::EXEC} license` command will validate the existing license
-        or will help you interactively generate new free/trial license and activate the
-        commercial license the chef team has sent you through email.
-      HELP
+#         `#{ChefCLI::Dist::EXEC} license` command will validate the existing license
+#         or will help you interactively generate new free/trial license and activate the
+#         commercial license the chef team has sent you through email.
+#       HELP
 
-      SUB_COMMANDS = [
-        { name: "list", description: "List details of the license(s) installed on the system." },
-        { name: "add", description: "Create & install a Free/ Trial license or install a Commercial license on the system." },
-      ].freeze
+#       SUB_COMMANDS = [
+#         { name: "list", description: "List details of the license(s) installed on the system." },
+#         { name: "add", description: "Create & install a Free/ Trial license or install a Commercial license on the system." },
+#       ].freeze
 
-      option :chef_license_key,
-        long: "--chef-license-key LICENSE",
-        description: "New license key to accept and store in the system"
+#       option :chef_license_key,
+#         long: "--chef-license-key LICENSE",
+#         description: "New license key to accept and store in the system"
 
-      attr_accessor :ui
+#       attr_accessor :ui
 
-      def self.banner
-        <<~BANNER
-          #{MAIN_COMMAND_HELP}
-          Subcommands:
-          #{SUB_COMMANDS.map do |c|
-            "  #{c[:name].ljust(7)}#{c[:description]}"
-          end.join("\n") }
+#       def self.banner
+#         <<~BANNER
+#           #{MAIN_COMMAND_HELP}
+#           Subcommands:
+#           #{SUB_COMMANDS.map do |c|
+#             "  #{c[:name].ljust(7)}#{c[:description]}"
+#           end.join("\n") }
 
-          Options:
-        BANNER
-      end
+#           Options:
+#         BANNER
+#       end
 
-      def initialize
-        super
+#       def initialize
+#         super
 
-        @ui = UI.new
-      end
+#         @ui = UI.new
+#       end
 
-      def run(params)
-        config_license_debug if debug?
-        remaining_args = parse_options(params)
-        return 1 unless validate_params!(remaining_args)
+#       def run(params)
+#         config_license_debug if debug?
+#         remaining_args = parse_options(params)
+#         return 1 unless validate_params!(remaining_args)
 
-        if remaining_args.blank?
-          ChefCLI::Licensing::Base.validate
-        else
-          ChefCLI::Licensing::Base.send(remaining_args[0])
-        end
-      rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
-        ui.msg("License key not fetched. Please try again.")
-      end
+#         if remaining_args.blank?
+#           ChefCLI::Licensing::Base.validate
+#         else
+#           ChefCLI::Licensing::Base.send(remaining_args[0])
+#         end
+#       rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
+#         ui.msg("License key not fetched. Please try again.")
+#       end
 
-      def debug?
-        !!config[:debug]
-      end
+#       def debug?
+#         !!config[:debug]
+#       end
 
-      def validate_params!(args)
-        if args.length > 1
-          ui.err("Too many arguments")
-          return false
-        end
+#       def validate_params!(args)
+#         if args.length > 1
+#           ui.err("Too many arguments")
+#           return false
+#         end
 
-        valid_subcommands = SUB_COMMANDS.collect { |c| c[:name] }
-        args.each do |arg|
-          next if valid_subcommands.include?(arg)
+#         valid_subcommands = SUB_COMMANDS.collect { |c| c[:name] }
+#         args.each do |arg|
+#           next if valid_subcommands.include?(arg)
 
-          ui.err("Invalid option: #{arg}")
-          return false
-        end
+#           ui.err("Invalid option: #{arg}")
+#           return false
+#         end
 
-        true
-      end
+#         true
+#       end
 
-      private
+#       private
 
-      def config_license_debug
-        ChefLicensing.output = ui
-      end
-    end
-  end
-end
+#       def config_license_debug
+#         ChefLicensing.output = ui
+#       end
+#     end
+#   end
+# end

--- a/lib/chef-cli/licensing/base.rb
+++ b/lib/chef-cli/licensing/base.rb
@@ -16,27 +16,27 @@
 # limitations under the License.
 #
 
-require "chef-licensing"
-require_relative "config"
+# require "chef-licensing"
+# require_relative "config"
 
-module ChefCLI
-  module Licensing
-    class Base
-      class << self
-        def validate
-          ChefLicensing.fetch_and_persist.each do |license_key|
-            puts "License Key: #{license_key}"
-          end
-        end
+# module ChefCLI
+#   module Licensing
+#     class Base
+#       class << self
+#         def validate
+#           ChefLicensing.fetch_and_persist.each do |license_key|
+#             puts "License Key: #{license_key}"
+#           end
+#         end
 
-        def list
-          ChefLicensing.list_license_keys_info
-        end
+#         def list
+#           ChefLicensing.list_license_keys_info
+#         end
 
-        def add
-          ChefLicensing.add_license
-        end
-      end
-    end
-  end
-end
+#         def add
+#           ChefLicensing.add_license
+#         end
+#       end
+#     end
+#   end
+# end

--- a/lib/chef-cli/licensing/config.rb
+++ b/lib/chef-cli/licensing/config.rb
@@ -16,11 +16,11 @@
 # limitations under the License.
 #
 
-require "chef-licensing"
+# require "chef-licensing"
 
-ChefLicensing.configure do |config|
-  config.chef_product_name = "workstation"
-  config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
-  config.chef_executable_name = "chef"
-  config.license_server_url = "https://services.chef.io/licensing"
-end
+# ChefLicensing.configure do |config|
+#   config.chef_product_name = "workstation"
+#   config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+#   config.chef_executable_name = "chef"
+#   config.license_server_url = "https://services.chef.io/licensing"
+# end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -90,7 +90,7 @@ describe ChefCLI::CLI do
     commands_map.builtin "example", :TestCommand, require_path: "unit/fixtures/command/cli_test_command",
                                                   desc: "Example subcommand for testing"
 
-    allow(ChefCLI::Licensing::Base).to receive(:validate).and_return(true)
+    # allow(ChefCLI::Licensing::Base).to receive(:validate).and_return(true)
   end
 
   context "given no arguments or options" do

--- a/spec/unit/command/license_spec.rb
+++ b/spec/unit/command/license_spec.rb
@@ -15,148 +15,148 @@
 # limitations under the License.
 #
 
-require "spec_helper"
-require "chef-cli/command/license"
-require "shared/command_with_ui_object"
-require "chef-cli/licensing/base"
+# require "spec_helper"
+# require "chef-cli/command/license"
+# require "shared/command_with_ui_object"
+# require "chef-cli/licensing/base"
 
-describe ChefCLI::Command::License do
-  it_behaves_like "a command with a UI object"
+# describe ChefCLI::Command::License do
+#   it_behaves_like "a command with a UI object"
 
-  let(:params) { [] }
-  let(:ui) { TestHelpers::TestUI.new }
+#   let(:params) { [] }
+#   let(:ui) { TestHelpers::TestUI.new }
 
-  before do
-    # Disable the access of local licenses
-    allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_arg).and_return([])
-    allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_env).and_return([])
-    allow_any_instance_of(ChefLicensing::LicensingService::Local).to receive(:detected?).and_return(false)
-  end
+#   before do
+#     # Disable the access of local licenses
+#     allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_arg).and_return([])
+#     allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:fetch_license_key_from_env).and_return([])
+#     allow_any_instance_of(ChefLicensing::LicensingService::Local).to receive(:detected?).and_return(false)
+#   end
 
-  let(:command) do
-    c = described_class.new
-    c.validate_params!(params)
-    c.ui = ui
-    c
-  end
+#   let(:command) do
+#     c = described_class.new
+#     c.validate_params!(params)
+#     c.ui = ui
+#     c
+#   end
 
-  it "disables debug by default" do
-    expect(command.debug?).to be(false)
-  end
+#   it "disables debug by default" do
+#     expect(command.debug?).to be(false)
+#   end
 
-  context "invalid parameters passed" do
-    let(:multiple_params) { %w{add list} }
-    let(:invalid_command) { %w{not_a_subcommand} }
+#   context "invalid parameters passed" do
+#     let(:multiple_params) { %w{add list} }
+#     let(:invalid_command) { %w{not_a_subcommand} }
 
-    it "should fail with errors when multiple subcommands passed" do
-      expect(command.run(multiple_params)).to eq(1)
-    end
+#     it "should fail with errors when multiple subcommands passed" do
+#       expect(command.run(multiple_params)).to eq(1)
+#     end
 
-    it "should fail for invalid argument" do
-      expect(command.run(invalid_command)).to eq(1)
-    end
-  end
+#     it "should fail for invalid argument" do
+#       expect(command.run(invalid_command)).to eq(1)
+#     end
+#   end
 
-  context "license command" do
-    context "when pre-accepted license exists" do
-      let(:license_keys) { %w{tsmc-abcd} }
+#   context "license command" do
+#     context "when pre-accepted license exists" do
+#       let(:license_keys) { %w{tsmc-abcd} }
 
-      before(:each) do
-        allow(ChefLicensing).to receive(:fetch_and_persist).and_return(license_keys)
-      end
+#       before(:each) do
+#         allow(ChefLicensing).to receive(:fetch_and_persist).and_return(license_keys)
+#       end
 
-      it "should be successful" do
-        expect { command.run(params) }.not_to raise_exception
-      end
+#       it "should be successful" do
+#         expect { command.run(params) }.not_to raise_exception
+#       end
 
-      it "should return the correct license key" do
-        expect(command.run(params)).to eq(license_keys)
-      end
-    end
+#       it "should return the correct license key" do
+#         expect(command.run(params)).to eq(license_keys)
+#       end
+#     end
 
-    context "when no licenses are accepted previously" do
-      let(:new_key) { ["tsmc-123456789"] }
-      before(:each) do
-        ChefLicensing.configure do |config|
-          config.license_server_url = "https://license.test"
-          config.chef_product_name = "chef"
-          config.chef_entitlement_id = "chef-entitled-id"
-          config.chef_executable_name = "chef"
-        end
+#     context "when no licenses are accepted previously" do
+#       let(:new_key) { ["tsmc-123456789"] }
+#       before(:each) do
+#         ChefLicensing.configure do |config|
+#           config.license_server_url = "https://license.test"
+#           config.chef_product_name = "chef"
+#           config.chef_entitlement_id = "chef-entitled-id"
+#           config.chef_executable_name = "chef"
+#         end
 
-        # Disable the active license check
-        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:licenses_active?).and_return(false)
-        # Disable the UI engine
-        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:append_extra_info_to_tui_engine)
-        # Disable the API call to fetch the license type
-        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:get_license_type).and_return("free")
-        # Disable the overwriting to the license.yml file
-        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::File).to receive(:persist)
+#         # Disable the active license check
+#         allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:licenses_active?).and_return(false)
+#         # Disable the UI engine
+#         allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:append_extra_info_to_tui_engine)
+#         # Disable the API call to fetch the license type
+#         allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:get_license_type).and_return("free")
+#         # Disable the overwriting to the license.yml file
+#         allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::File).to receive(:persist)
 
-        # Mocks the user prompt to enter the license
-        allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(new_key)
-        allow(ChefLicensing).to receive(:fetch_and_persist).and_return(new_key)
-      end
+#         # Mocks the user prompt to enter the license
+#         allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(new_key)
+#         allow(ChefLicensing).to receive(:fetch_and_persist).and_return(new_key)
+#       end
 
-      it "should create and stores the new license" do
-        expect { command.run(params) }.not_to raise_exception
-      end
+#       it "should create and stores the new license" do
+#         expect { command.run(params) }.not_to raise_exception
+#       end
 
-      it "should be same as the user entered license" do
-        expect(command.run(params)).to include(new_key.first)
-      end
-    end
-  end
+#       it "should be same as the user entered license" do
+#         expect(command.run(params)).to include(new_key.first)
+#       end
+#     end
+#   end
 
-  context "chef license list command" do
-    let(:params) { %w{list} }
-    let(:license_key) { "tsmn-123123" }
+#   context "chef license list command" do
+#     let(:params) { %w{list} }
+#     let(:license_key) { "tsmn-123123" }
 
-    before do
-      command.ui = ui
-    end
+#     before do
+#       command.ui = ui
+#     end
 
-    context "when no licenses are accepted" do
-      before do
-        allow_any_instance_of(ChefLicensing::ListLicenseKeys).to receive(:fetch_license_keys).and_return([])
-        allow_any_instance_of(ChefLicensing::ListLicenseKeys).to receive(:fetch_licenses_metadata).and_return([])
-      end
+#     context "when no licenses are accepted" do
+#       before do
+#         allow_any_instance_of(ChefLicensing::ListLicenseKeys).to receive(:fetch_license_keys).and_return([])
+#         allow_any_instance_of(ChefLicensing::ListLicenseKeys).to receive(:fetch_licenses_metadata).and_return([])
+#       end
 
-      it "should return the correct error message" do
-        expect(command.run(params)).to eq([])
-      end
-    end
+#       it "should return the correct error message" do
+#         expect(command.run(params)).to eq([])
+#       end
+#     end
 
-    context "when there is a valid license" do
-      before do
-        allow(ChefLicensing).to receive(:list_license_keys_info).and_return(license_key)
-      end
+#     context "when there is a valid license" do
+#       before do
+#         allow(ChefLicensing).to receive(:list_license_keys_info).and_return(license_key)
+#       end
 
-      it "should print the license details" do
-        expect(command.run(params)).to eq(license_key)
-      end
-    end
-  end
+#       it "should print the license details" do
+#         expect(command.run(params)).to eq(license_key)
+#       end
+#     end
+#   end
 
-  context "chef license add command" do
-    let(:params) { %w{add} }
-    let(:license_key) { ["tsmn-123123"] }
+#   context "chef license add command" do
+#     let(:params) { %w{add} }
+#     let(:license_key) { ["tsmn-123123"] }
 
-    before do
-      # Disable the API call to fetch the license type
-      allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:get_license_type).and_return("free")
-      # Disable the overwriting to the license.yml file
-      allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::File).to receive(:persist)
-      # Mocks the user prompt to enter the license
-      allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(license_key)
-    end
+#     before do
+#       # Disable the API call to fetch the license type
+#       allow_any_instance_of(ChefLicensing::LicenseKeyFetcher).to receive(:get_license_type).and_return("free")
+#       # Disable the overwriting to the license.yml file
+#       allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::File).to receive(:persist)
+#       # Mocks the user prompt to enter the license
+#       allow_any_instance_of(ChefLicensing::LicenseKeyFetcher::Prompt).to receive(:fetch).and_return(license_key)
+#     end
 
-    it "should not raise any errors" do
-      expect { command.run(params) }.not_to raise_exception
-    end
+#     it "should not raise any errors" do
+#       expect { command.run(params) }.not_to raise_exception
+#     end
 
-    it "should create and store the new license" do
-      expect(command.run(params)).to include(license_key.first)
-    end
-  end
-end
+#     it "should create and store the new license" do
+#       expect(command.run(params)).to include(license_key.first)
+#     end
+#   end
+# end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR will remove the following commands which were used to activate the license

- chef-cli license
- chef-cli license add
- chef-cli license list

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
