### PR TITLE
Fixing habitat test builds by declaring HAB_ORIGIN after habitat install

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -7,7 +7,6 @@ $PSDefaultParameterValues['*:ErrorAction']='Stop'
 $ErrorActionPreference = 'Stop'
 $env:HAB_BLDR_CHANNEL = "LTS-2024"
 $env:HAB_REFRESH_CHANNEL = "LTS-2024"
-$env:HAB_ORIGIN = 'ci'
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
 $Plan = 'chef-cli'
@@ -57,6 +56,10 @@ catch {
 finally {
   Write-Host ":habicat: I think I have the version I need to build."
 }
+
+# Set HAB_ORIGIN after Habitat installation
+Write-Host "HAB_ORIGIN set to 'ci' after installation."
+$env:HAB_ORIGIN = 'ci'
 
 
 Write-Host "--- Generating fake origin key"

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -2,7 +2,6 @@
 
 set -eo pipefail
 
-export HAB_ORIGIN='ci'
 export PLAN='chef-cli'
 export CHEF_LICENSE="accept-no-persist"
 export HAB_LICENSE="accept-no-persist"
@@ -40,6 +39,10 @@ uname -a
 echo "--- Installing Habitat"
 id -a
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+
+# Set HAB_ORIGIN after Habitat installation
+echo "--- Setting HAB_ORIGIN to 'ci' after installation"
+export HAB_ORIGIN='ci'
 
 echo "--- :key: Generating fake origin key"
 hab origin key generate "$HAB_ORIGIN"


### PR DESCRIPTION

## Description
After latest changes done in habitat, all the habitat test pipeline started failing in workstation and all components. In this PR we are fixing habitat test builds by declaring HAB_ORIGIN after habitat install

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
