### PR TITLE
add arm build/upload and promotion pipeline

### DIFF
--- a/.expeditor/build.habitat.aarch64.pipeline.yml
+++ b/.expeditor/build.habitat.aarch64.pipeline.yml
@@ -1,0 +1,28 @@
+---
+# Expeditor's built-in habitat/build does not support aarch64 targets.
+# This pipeline builds the aarch64-linux habitat package and uploads it
+# to the habitat builder (unstable channel).
+
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 120
+      retry:
+        automatic:
+          limit: 1
+
+steps:
+
+  - label: ":habicat: Build aarch64-linux habitat package"
+    commands:
+      - sudo -E ./.expeditor/buildkite/build_hab_aarch64.sh
+      - ./.expeditor/buildkite/upload_hab_aarch64.sh
+    agents:
+      queue: default-privileged-aarch64
+    plugins:
+      - docker#v3.5.0:
+          image: chefes/omnibus-toolchain-ubuntu-2204:aarch64
+          privileged: true
+          propagate-environment: true
+          environment:
+            - HAB_AUTH_TOKEN

--- a/.expeditor/buildkite/build_hab_aarch64.sh
+++ b/.expeditor/buildkite/build_hab_aarch64.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Builds the aarch64-linux chef-cli habitat package.
+# Expeditor's built-in habitat/build pipeline does not support aarch64 targets,
+# so this script handles the build as part of the hab_aarch64/build pipeline.
+
+set -euo pipefail
+
+export HAB_ORIGIN='chef'
+export PLAN='chef-cli'
+export CHEF_LICENSE="accept-no-persist"
+export HAB_LICENSE="accept-no-persist"
+export HAB_NONINTERACTIVE="true"
+export HAB_BLDR_CHANNEL="base-2025"
+export HAB_REFRESH_CHANNEL="base-2025"
+
+echo "--- :git: Checking for git"
+if ! command -v git &> /dev/null; then
+  echo "Git is not installed. Installing Git..."
+  sudo apt-get update -yq && sudo apt-get install -yq git
+else
+  echo "Git is already installed."
+  git --version
+fi
+
+echo "--- :git: Adding safe directory exception"
+git config --global --add safe.directory /workdir
+
+echo "--- :linux: Installing Habitat"
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+
+echo "--- :key: Downloading origin keys"
+hab origin key download "$HAB_ORIGIN"
+hab origin key download "$HAB_ORIGIN" --secret
+
+echo "--- :construction: Building $PLAN aarch64-linux package"
+hab pkg build . --refresh-channel base-2025
+
+project_root="$(pwd)"
+source "${project_root}/results/last_build.env" || { echo "ERROR: unable to determine build details"; exit 1; }
+
+echo "--- :package: Uploading artifact to Buildkite"
+cd "${project_root}/results"
+buildkite-agent artifact upload "$pkg_artifact" || { echo "ERROR: unable to upload artifact"; exit 1; }
+
+echo "--- Setting CHEF_CLI_HAB_ARTIFACT_LINUX_AARCH64 metadata for buildkite agent"
+buildkite-agent meta-data set "CHEF_CLI_HAB_ARTIFACT_LINUX_AARCH64" "$pkg_artifact"

--- a/.expeditor/buildkite/promote_hab_aarch64.sh
+++ b/.expeditor/buildkite/promote_hab_aarch64.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Promotes the aarch64-linux chef-cli package between
+# habitat channels. Expeditor's built-in promote_habitat_packages does not
+# support aarch64 targets, so this script handles it manually at each
+# promotion stage.
+#
+# Context is auto-detected from EXPEDITOR_ environment variables:
+#   - project_promoted:                    uses EXPEDITOR_SOURCE_CHANNEL → EXPEDITOR_TARGET_CHANNEL
+#   - buildkite_hab_build_group_published: defaults to unstable → current
+
+set -euo pipefail
+
+PKG_ORIGIN="chef"
+PKG_NAME="chef-cli"
+PKG_TARGET="aarch64-linux"
+
+export HAB_LICENSE="accept-no-persist"
+export HAB_NONINTERACTIVE="true"
+
+# Determine the package version from Expeditor environment variables.
+# For buildkite_hab_build_group_published, the aarch64 build is a separate
+# pipeline (hab_aarch64/build) that runs in parallel with habitat/build.
+# Both build from the same git commit so they produce the same version.
+# The aarch64 target is NOT in .bldr.toml so it's absent from pkg_idents;
+# we extract the version from the x86_64-linux ident instead.
+# Expeditor flattens Hash metadata keys by appending with "_" and stripping
+# non-word chars (\W), then uppercases the key, so:
+#   pkg_idents["chef-cli-x86_64-linux"]
+#   -> EXPEDITOR_PKG_IDENTS_CHEFCLIX86_64LINUX
+PKG_VERSION="${EXPEDITOR_PKG_VERSION:-${EXPEDITOR_PROMOTABLE:-}}"
+if [[ -z "$PKG_VERSION" && -n "${EXPEDITOR_PKG_IDENTS_CHEFCLIX86_64LINUX:-}" ]]; then
+  PKG_VERSION=$(echo "${EXPEDITOR_PKG_IDENTS_CHEFCLIX86_64LINUX}" | cut -d'/' -f3)
+fi
+
+# Determine source and target channels based on Expeditor workload context
+if [[ -n "${EXPEDITOR_TARGET_CHANNEL:-}" ]]; then
+  # project_promoted workload
+  SOURCE_CHANNEL="${EXPEDITOR_SOURCE_CHANNEL}"
+  TARGET_CHANNEL="${EXPEDITOR_TARGET_CHANNEL}"
+else
+  # buildkite_hab_build_group_published workload
+  SOURCE_CHANNEL="unstable"
+  TARGET_CHANNEL="current"
+fi
+
+echo "--- Promoting ${PKG_ORIGIN}/${PKG_NAME} (${PKG_TARGET}) from ${SOURCE_CHANNEL} to ${TARGET_CHANNEL}"
+
+# Use HAB_AUTH_TOKEN from the pipeline secret if available, otherwise fetch from vault
+if [[ -z "${HAB_AUTH_TOKEN:-}" ]]; then
+  HAB_AUTH_TOKEN=$(vault kv get -field auth_token account/static/habitat/chef-ci)
+  export HAB_AUTH_TOKEN
+fi
+
+# Find the exact aarch64 package ident for this version
+if [[ -n "$PKG_VERSION" ]]; then
+  echo "--- Looking up ${PKG_TARGET} package for version ${PKG_VERSION}"
+  PKG_IDENT=$(curl -sf "https://bldr.habitat.sh/v1/depot/pkgs/${PKG_ORIGIN}/${PKG_NAME}/${PKG_VERSION}/latest?target=${PKG_TARGET}" | jq -r '.ident_array | join("/")')
+else
+  echo "WARNING: No version info available. Skipping aarch64 promotion."
+  exit 0
+fi
+
+if [[ -z "$PKG_IDENT" || "$PKG_IDENT" == "null" ]]; then
+  echo "WARNING: No ${PKG_TARGET} package found for version ${PKG_VERSION}. Skipping promotion."
+  exit 0
+fi
+
+echo "--- Found package: ${PKG_IDENT}"
+echo "--- Promoting ${PKG_IDENT} to ${TARGET_CHANNEL} channel"
+
+hab pkg promote "${PKG_IDENT}" "${TARGET_CHANNEL}" "${PKG_TARGET}"
+
+echo "--- Successfully promoted ${PKG_IDENT} (${PKG_TARGET}) to ${TARGET_CHANNEL}"

--- a/.expeditor/buildkite/upload_hab_aarch64.sh
+++ b/.expeditor/buildkite/upload_hab_aarch64.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Uploads the aarch64-linux habitat package to the habitat builder.
+# Expeditor's built-in habitat/build pipeline does not support aarch64 targets,
+# so this script handles the upload as part of the build pipeline.
+
+set -euo pipefail
+
+export HAB_ORIGIN='chef'
+export CHEF_LICENSE="accept-no-persist"
+export HAB_LICENSE="accept-no-persist"
+export HAB_NONINTERACTIVE="true"
+
+error () {
+  local message="$1"
+  echo -e "\nERROR: ${message}\n" >&2
+  exit 1
+}
+
+echo "--- Downloading aarch64 package artifact"
+PKG_ARTIFACT=$(buildkite-agent meta-data get "CHEF_CLI_HAB_ARTIFACT_LINUX_AARCH64")
+buildkite-agent artifact download "$PKG_ARTIFACT" . || error 'unable to download aarch64 artifact'
+
+echo "--- :habicat: Uploading aarch64 package to habitat builder (unstable channel)"
+hab pkg upload "$PKG_ARTIFACT" --auth "$HAB_AUTH_TOKEN" --channel unstable || error 'unable to upload aarch64 package to habitat builder'

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -43,6 +43,9 @@ pipelines:
         - HAB_NONINTERACTIVE: "true"
         - HAB_NOCOLORING: "true"
         - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
+  - hab_aarch64/build:
+      description: Build and upload aarch64-linux habitat package
+      definition: .expeditor/build.habitat.aarch64.pipeline.yml
   - habitat/test:
       public: true
       description: Execute tests against the habitat artifact
@@ -52,6 +55,9 @@ pipelines:
         - HAB_NOCOLORING: "true"
         - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
       trigger: pull_request
+  - promote_hab_aarch64:
+      description: Promote aarch64-linux habitat package between channels
+      definition: .expeditor/promote.habitat.aarch64.pipeline.yml
 
 subscriptions:
   # These actions are taken, in order they are specified, anytime a Pull Request is merged.
@@ -74,11 +80,17 @@ subscriptions:
           ignore_labels:
             - "Expeditor: Skip Habitat"
             - "Expeditor: Skip All"
+      - trigger_pipeline:hab_aarch64/build:
+          only_if: built_in:bump_version
+          ignore_labels:
+            - "Expeditor: Skip Habitat"
+            - "Expeditor: Skip All"
 
   # Automatically promote the Habitat packages from unstable to current upon successful build of habitat/build
   - workload: buildkite_hab_build_group_published:{{agent_id}}:*
     actions:
       - built_in:promote_habitat_packages
+      # - trigger_pipeline:promote_hab_aarch64
 
   # Promoting current to base-2025 channel
   # this works for symantec version promote
@@ -86,5 +98,6 @@ subscriptions:
     actions:
       - built_in:rollover_changelog
       - built_in:promote_habitat_packages
+      # - trigger_pipeline:promote_hab_aarch64
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels

--- a/.expeditor/promote.habitat.aarch64.pipeline.yml
+++ b/.expeditor/promote.habitat.aarch64.pipeline.yml
@@ -1,0 +1,26 @@
+---
+# Pipeline to promote the aarch64-linux chef-cli habitat
+# package between channels. Replaces the inline bash action so promotion runs
+# as a tracked Buildkite pipeline with its own logs and retry controls.
+#
+# The promote_hab_aarch64.sh script auto-detects source/target channels
+# from EXPEDITOR_ environment variables set by the triggering workload.
+
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 10
+      retry:
+        automatic:
+          limit: 1
+
+steps:
+
+  - label: ":habicat: Promote aarch64-linux habitat package"
+    command:
+      - ./.expeditor/buildkite/promote_hab_aarch64.sh
+    expeditor:
+      secrets:
+        HAB_AUTH_TOKEN:
+          path: account/static/habitat/chef-ci
+          field: auth_token


### PR DESCRIPTION
## Description
These changes add habitat arm builds. Since expeditor doesn't have native arm support right now, we add pipelines to upload and promote packages manually through scripts.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
