### PR TITLE
CHEF-31159 Setup common config to block PR merges if trufflehog fails

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
+++ b/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
@@ -104,6 +104,7 @@ jobs:
       # scc-output-filename: 'scc-output.txt'
       perform-language-linting: false    # Perform language-specific linting and pre-compilation checks
       perform-trufflehog-scan: true
+      fail-trufflehog-on-secrets-found: true
       perform-trivy-scan: true
 
       # grype vulnerability scanning


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR updates the CI workflow configuration to block PR merges when Trufflehog detects secrets.

Added fail-trufflehog-on-secrets-found: true to fail builds when secrets are detected.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
