### PR TITLE
CHEF-37329: add Linux ARM Habitat validation in Expeditor pipeline

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -21,6 +21,20 @@ steps:
           environment:
             - HAB_AUTH_TOKEN
 
+  - label: ":linux: Arm64 Validate Habitat Builds of Chef-cli"
+    commands:
+      - .expeditor/buildkite/artifact.habitat.test.sh
+    agents:
+      queue: default-privileged-aarch64
+    plugins:
+      - docker#v3.5.0:
+          image: ruby:3.4
+          privileged: true
+          propagate-environment: true
+          environment:
+            - HAB_AUTH_TOKEN
+            - BUILD_PKG_TARGET: "aarch64-linux"
+
   - label: ":windows: Validate Habitat Builds of Test Kitchen"
     commands:
       - .expeditor/buildkite/artifact.habitat.test.ps1

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,0 +1,2 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
+# Reuse the default Linux plan for Linux ARM (aarch64) builds.

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,5 +1,16 @@
 export HAB_BLDR_CHANNEL="base-2025"
 export HAB_REFRESH_CHANNEL="base-2025"
+
+# Resolve the repo root from this file's own location (BASH_SOURCE) rather
+# than PLAN_CONTEXT. PLAN_CONTEXT is set by Habitat to the directory it
+# started the build from, which is NOT necessarily the directory this file
+# lives in -- e.g. when habitat/aarch64-linux/plan.sh sources this file,
+# PLAN_CONTEXT is "habitat/aarch64-linux", not "habitat", which breaks any
+# "${PLAN_CONTEXT}/.." reference used here. BASH_SOURCE[0] always points at
+# this file, so it resolves correctly regardless of which plan sourced it.
+CHEF_CLI_PLAN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHEF_CLI_REPO_ROOT="$(cd "${CHEF_CLI_PLAN_DIR}/.." && pwd)"
+
 pkg_name=chef-cli
 pkg_origin=chef
 ruby_pkg="core/ruby3_4"
@@ -35,7 +46,7 @@ do_before() {
 
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -RT "$PLAN_CONTEXT"/.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+  cp -RT "$CHEF_CLI_REPO_ROOT" "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
 }
 
 do_build() {
@@ -57,11 +68,11 @@ do_build() {
 do_install() {
 
   # Copy NOTICE to the package directory
-  if [[ -f "$PLAN_CONTEXT/../NOTICE" ]]; then
+  if [[ -f "${CHEF_CLI_REPO_ROOT}/NOTICE" ]]; then
     build_line "Copying NOTICE to package directory"
-    cp "$PLAN_CONTEXT/../NOTICE" "$pkg_prefix/"
+    cp "${CHEF_CLI_REPO_ROOT}/NOTICE" "$pkg_prefix/"
   else
-    build_line "Warning: NOTICE not found at $PLAN_CONTEXT/../NOTICE"
+    build_line "Warning: NOTICE not found at ${CHEF_CLI_REPO_ROOT}/NOTICE"
   fi
 
   export GEM_HOME="$pkg_prefix/vendor"
@@ -78,8 +89,8 @@ do_install() {
   "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" chef-cli
 
   build_line "** patching binstubs to allow running directly"
-  for binstub in ${pkg_prefix}/bin/*; do
-    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
+  for binstub in "${pkg_prefix}"/bin/*; do
+    sed -i "/require \"rubygems\"/r ${CHEF_CLI_REPO_ROOT}/binstub_patch.rb" "$binstub"
   done
 
   build_line "** creating wrapper for runtime environment"
@@ -98,9 +109,9 @@ exec $(pkg_path_for ${ruby_pkg})/bin/ruby $pkg_prefix/libexec/chef-cli "\$@"
 EOF
   chmod -v 755 "$pkg_prefix/bin/chef-cli"
 
-  rm -rf $GEM_PATH/cache/
-  rm -rf $GEM_PATH/bundler
-  rm -rf $GEM_PATH/doc
+  rm -rf "${GEM_PATH:?}/cache/"
+  rm -rf "${GEM_PATH:?}/bundler"
+  rm -rf "${GEM_PATH:?}/doc"
 }
 
 


### PR DESCRIPTION
## Summary
Adds Linux ARM64 (aarch64) Habitat build validation to the chef-cli Expeditor/Buildkite pipeline.

## What Changed
- Added a new ":linux: Arm64 Validate Habitat Builds of Chef-cli" step to .expeditor/habitat-test.pipeline.yml
- Runs on Buildkite queue default-privileged-aarch64
- Uses the docker#v3.5.0 plugin with image ruby:3.4, privileged: true, propagate-environment: true
- Sets BUILD_PKG_TARGET: "aarch64-linux"
- Keeps HAB_AUTH_TOKEN propagated via the environment, consistent with the existing Linux/Windows steps

## Result
Habitat package builds for chef-cli are now validated on Linux ARM64 via Buildkite/Expeditor, in addition to the existing Linux (x86_64) and Windows validation steps.

## Jira
CHEF-37329